### PR TITLE
Style/#47: 색상 및 텍스트 스타일을 디자인 시스템을 적용하여 변경

### DIFF
--- a/TinyBite/app/(auth)/_layout.tsx
+++ b/TinyBite/app/(auth)/_layout.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Stack } from "expo-router";
 import { StyleSheet, View } from "react-native";
 
@@ -8,7 +9,7 @@ export default function AuthLayout() {
         screenOptions={{
           headerShown: false,
           animation: "slide_from_right",
-          contentStyle: { backgroundColor: "#FCFBFF" },
+          contentStyle: { backgroundColor: colors.background },
         }}
       />
     </View>
@@ -18,6 +19,6 @@ export default function AuthLayout() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#FCFBFF",
+    backgroundColor: colors.background,
   },
 });

--- a/TinyBite/app/(auth)/login/login.tsx
+++ b/TinyBite/app/(auth)/login/login.tsx
@@ -94,6 +94,6 @@ const styles = StyleSheet.create({
   google: { backgroundColor: colors.white },
   apple: { backgroundColor: colors.white },
   socialText: {
-    color: "#222",
+    color: colors.black,
   },
 });

--- a/TinyBite/app/(auth)/login/login.tsx
+++ b/TinyBite/app/(auth)/login/login.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
@@ -36,7 +37,9 @@ export default function LoginScreen() {
           onPress={() => handleLoginPress("kakao")}
         >
           <Image source={require("@/assets/images/login/icon-kakao.png")} />
-          <Text style={styles.socialText}>카카오로 시작하기</Text>
+          <Text style={[styles.socialText, textStyles.title18_SB135]}>
+            카카오로 시작하기
+          </Text>
         </TouchableOpacity>
 
         <TouchableOpacity
@@ -44,7 +47,9 @@ export default function LoginScreen() {
           onPress={() => handleLoginPress("google")}
         >
           <Image source={require("@/assets/images/login/icon-google.png")} />
-          <Text style={styles.socialText}>Google로 시작하기</Text>
+          <Text style={[styles.socialText, textStyles.title18_SB135]}>
+            Google로 시작하기
+          </Text>
         </TouchableOpacity>
 
         <TouchableOpacity
@@ -52,7 +57,9 @@ export default function LoginScreen() {
           onPress={() => handleLoginPress("apple")}
         >
           <Image source={require("@/assets/images/login/icon-apple.png")} />
-          <Text style={styles.socialText}>Apple로 시작하기</Text>
+          <Text style={[styles.socialText, textStyles.title18_SB135]}>
+            Apple로 시작하기
+          </Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -88,9 +95,5 @@ const styles = StyleSheet.create({
   apple: { backgroundColor: colors.white },
   socialText: {
     color: "#222",
-    fontSize: 18,
-    fontStyle: "normal",
-    fontWeight: 600,
-    lineHeight: 24.3,
   },
 });

--- a/TinyBite/app/(auth)/login/login.tsx
+++ b/TinyBite/app/(auth)/login/login.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
@@ -63,7 +64,7 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: 120,
     paddingHorizontal: 20,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
     justifyContent: "center",
     alignItems: "center",
   },
@@ -83,8 +84,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   kakao: { backgroundColor: "#FEE500" },
-  google: { backgroundColor: "#FFFFFF" },
-  apple: { backgroundColor: "#FFFFFF" },
+  google: { backgroundColor: colors.white },
+  apple: { backgroundColor: colors.white },
   socialText: {
     color: "#222",
     fontSize: 18,

--- a/TinyBite/app/(auth)/signup/complete.tsx
+++ b/TinyBite/app/(auth)/signup/complete.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { router } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
@@ -25,7 +26,9 @@ export default function CompleteScreen() {
           style={styles.nextBtn}
           onPress={() => router.replace("/(tabs)")}
         >
-          <Text style={styles.nextText}>내 동네 파티 목록 확인하기</Text>
+          <Text style={[styles.nextText, textStyles.title18_SB135]}>
+            내 동네 파티 목록 확인하기
+          </Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -58,9 +61,6 @@ const styles = StyleSheet.create({
   },
   nextText: {
     color: "#fff",
-    fontSize: 18,
-    fontWeight: 600,
-    lineHeight: 24.3,
     textAlign: "center",
   },
 });

--- a/TinyBite/app/(auth)/signup/complete.tsx
+++ b/TinyBite/app/(auth)/signup/complete.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { router } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
@@ -41,7 +42,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   contentText: {
-    color: "#FE870F",
+    color: colors.main,
     textAlign: "center",
     fontSize: 32,
     fontWeight: 700,
@@ -53,7 +54,7 @@ const styles = StyleSheet.create({
   nextBtn: {
     paddingVertical: 16,
     borderRadius: 16,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
   },
   nextText: {
     color: "#fff",

--- a/TinyBite/app/(auth)/signup/complete.tsx
+++ b/TinyBite/app/(auth)/signup/complete.tsx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.main,
   },
   nextText: {
-    color: "#fff",
+    color: colors.white,
     textAlign: "center",
   },
 });

--- a/TinyBite/app/(auth)/signup/nickname.tsx
+++ b/TinyBite/app/(auth)/signup/nickname.tsx
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     justifyContent: "center",
     alignItems: "flex-start",
-    backgroundColor: "#fff",
+    backgroundColor: colors.white,
     borderRadius: 16,
     borderWidth: 0,
     // 그림자 효과 (iOS)
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   label: {
-    color: "#888",
+    color: colors.gray[1],
   },
   input: {
     alignSelf: "stretch",
@@ -114,7 +114,7 @@ const styles = StyleSheet.create({
     margin: 0,
   },
   count: {
-    color: "#aaa",
+    color: colors.gray[2],
     textAlign: "right",
   },
 

--- a/TinyBite/app/(auth)/signup/nickname.tsx
+++ b/TinyBite/app/(auth)/signup/nickname.tsx
@@ -1,5 +1,6 @@
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useState } from "react";
@@ -38,24 +39,30 @@ export default function NicknameScreen() {
         </View>
 
         {/* 닉네임 입력 */}
-        <Text style={styles.title}>{`사용하실 닉네임을 \n입력해 주세요.`}</Text>
+        <Text
+          style={[styles.title, textStyles.title24_SB135]}
+        >{`사용하실 닉네임을 \n입력해 주세요.`}</Text>
         <View style={styles.inputContainer}>
-          <Text style={styles.label}>닉네임</Text>
+          <Text style={[styles.label, textStyles.body16_SB135]}>닉네임</Text>
           <View style={{ alignSelf: "stretch" }}>
             <TextInput
-              style={styles.input}
+              style={[styles.input, textStyles.title18_SB135]}
               onChangeText={handleTextChange}
               value={nickname}
               placeholder="닉네임 (2~12자)"
               keyboardType="default"
               maxLength={12}
             />
-            <Text style={styles.count}>({nickname.length}/12)</Text>
+            <Text style={[styles.count, textStyles.body12_M135]}>
+              ({nickname.length}/12)
+            </Text>
           </View>
         </View>
 
         <View style={styles.row}>
-          <Text style={styles.status}>이미 사용 중인 닉네임입니다.</Text>
+          <Text style={[styles.status, textStyles.body16_M135]}>
+            이미 사용 중인 닉네임입니다.
+          </Text>
         </View>
 
         {/* 다음 버튼 */}
@@ -64,7 +71,7 @@ export default function NicknameScreen() {
           disabled={!verified}
           onPress={() => router.push("/signup/region")}
         >
-          <Text style={styles.nextText}>다음</Text>
+          <Text style={[styles.nextText, textStyles.title18_SB135]}>다음</Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -76,9 +83,6 @@ const styles = StyleSheet.create({
   inner: { flex: 1, position: "relative" },
 
   title: {
-    fontSize: 24,
-    fontWeight: "600",
-    lineHeight: 32.4,
     marginBottom: 28,
     color: colors.main,
   },
@@ -101,24 +105,15 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   label: {
-    fontSize: 16,
-    fontWeight: 600,
-    lineHeight: 21.6,
     color: "#888",
   },
   input: {
     alignSelf: "stretch",
-    fontSize: 18,
-    fontWeight: "600",
-    lineHeight: 24.3,
     color: "#000",
     padding: 0,
     margin: 0,
   },
   count: {
-    fontSize: 12,
-    fontWeight: 500,
-    lineHeight: 16.2,
     color: "#aaa",
     textAlign: "right",
   },
@@ -128,9 +123,6 @@ const styles = StyleSheet.create({
   },
   status: {
     color: colors.red[1],
-    fontSize: 16,
-    fontWeight: 500,
-    lineHeight: 21.6,
   },
 
   nextBtn: {
@@ -146,9 +138,6 @@ const styles = StyleSheet.create({
   },
   nextText: {
     color: colors.white,
-    fontSize: 18,
-    fontWeight: 600,
-    lineHeight: 24.3,
   },
   disabled: { opacity: 0.3 },
 });

--- a/TinyBite/app/(auth)/signup/nickname.tsx
+++ b/TinyBite/app/(auth)/signup/nickname.tsx
@@ -1,4 +1,5 @@
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useState } from "react";
@@ -79,7 +80,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     lineHeight: 32.4,
     marginBottom: 28,
-    color: "#FE870F",
+    color: colors.main,
   },
 
   inputContainer: {
@@ -125,21 +126,26 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
   },
-  status: { color: "#E93838", fontSize: 16, fontWeight: 500, lineHeight: 21.6 },
+  status: {
+    color: colors.red[1],
+    fontSize: 16,
+    fontWeight: 500,
+    lineHeight: 21.6,
+  },
 
   nextBtn: {
     position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
     justifyContent: "center",
     alignItems: "center",
     paddingVertical: 16,
     borderRadius: 16,
   },
   nextText: {
-    color: "#ffffff",
+    color: colors.white,
     fontSize: 18,
     fontWeight: 600,
     lineHeight: 24.3,

--- a/TinyBite/app/(auth)/signup/region.tsx
+++ b/TinyBite/app/(auth)/signup/region.tsx
@@ -55,7 +55,7 @@ export default function RegionScreen() {
               onChangeText={handleTextChange}
               value={text}
               placeholder="동명(읍,면)으로 검색 (ex.역삼동)"
-              placeholderTextColor="#888"
+              placeholderTextColor={colors.gray[1]}
               keyboardType="default"
               maxLength={8}
             />
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
     gap: 4,
     padding: 12,
     marginBottom: 12,
-    backgroundColor: "#fff",
+    backgroundColor: colors.white,
     borderRadius: 16,
     borderWidth: 0,
     // 그림자 효과 (iOS)

--- a/TinyBite/app/(auth)/signup/region.tsx
+++ b/TinyBite/app/(auth)/signup/region.tsx
@@ -1,5 +1,6 @@
 import LocationSearchResult from "@/components/LocationSearchResult";
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useState } from "react";
@@ -95,7 +96,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     lineHeight: 32.4,
     marginBottom: 28,
-    color: "#FE870F",
+    color: colors.main,
   },
 
   inputContainer: {
@@ -131,24 +132,24 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 4,
     borderRadius: 16,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
   },
   findText: {
-    color: "#ffffff",
+    color: colors.white,
     fontSize: 15,
     fontWeight: 600,
     lineHeight: 20.25,
   },
 
   nextBtn: {
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
     justifyContent: "center",
     alignItems: "center",
     paddingVertical: 16,
     borderRadius: 16,
   },
   nextText: {
-    color: "#ffffff",
+    color: colors.white,
     fontSize: 18,
     fontWeight: 600,
     lineHeight: 24.3,

--- a/TinyBite/app/(auth)/signup/region.tsx
+++ b/TinyBite/app/(auth)/signup/region.tsx
@@ -1,6 +1,7 @@
 import LocationSearchResult from "@/components/LocationSearchResult";
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useState } from "react";
@@ -41,7 +42,7 @@ export default function RegionScreen() {
         {/* 동네 설정 */}
         <View style={{ marginBottom: 10 }}>
           <Text
-            style={styles.title}
+            style={[styles.title, textStyles.title24_SB135]}
           >{`내 동네를 설정하고 \n근처 이웃과 딱 필요한 만큼 나눠요!`}</Text>
 
           <View style={styles.inputContainer}>
@@ -50,7 +51,7 @@ export default function RegionScreen() {
               style={{ width: 24, height: 24, aspectRatio: 1 / 1 }}
             />
             <TextInput
-              style={styles.input}
+              style={[styles.input, textStyles.title18_SB135]}
               onChangeText={handleTextChange}
               value={text}
               placeholder="동명(읍,면)으로 검색 (ex.역삼동)"
@@ -68,7 +69,9 @@ export default function RegionScreen() {
               source={require("@/assets/images/location-tracking.png")}
               style={{ width: 24, height: 24, aspectRatio: 1 / 1 }}
             />
-            <Text style={styles.findText}>현재 위치로 주소 찾기</Text>
+            <Text style={[styles.findText, textStyles.body15_SB135]}>
+              현재 위치로 주소 찾기
+            </Text>
           </TouchableOpacity>
         </View>
 
@@ -80,7 +83,7 @@ export default function RegionScreen() {
           disabled={!verified}
           onPress={() => router.replace("/(auth)/signup/complete")}
         >
-          <Text style={styles.nextText}>다음</Text>
+          <Text style={[styles.nextText, textStyles.title18_SB135]}>다음</Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -92,9 +95,6 @@ const styles = StyleSheet.create({
   inner: { flex: 1 },
 
   title: {
-    fontSize: 24,
-    fontWeight: "600",
-    lineHeight: 32.4,
     marginBottom: 28,
     color: colors.main,
   },
@@ -118,9 +118,6 @@ const styles = StyleSheet.create({
   input: {
     flex: 1,
     alignSelf: "stretch",
-    fontSize: 18,
-    fontWeight: "600",
-    lineHeight: 24.3,
     color: "#000",
     padding: 0,
     margin: 0,
@@ -136,9 +133,6 @@ const styles = StyleSheet.create({
   },
   findText: {
     color: colors.white,
-    fontSize: 15,
-    fontWeight: 600,
-    lineHeight: 20.25,
   },
 
   nextBtn: {
@@ -150,9 +144,6 @@ const styles = StyleSheet.create({
   },
   nextText: {
     color: colors.white,
-    fontSize: 18,
-    fontWeight: 600,
-    lineHeight: 24.3,
   },
   disabled: { opacity: 0.3 },
 });

--- a/TinyBite/app/(auth)/signup/terms.tsx
+++ b/TinyBite/app/(auth)/signup/terms.tsx
@@ -2,6 +2,7 @@ import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
 import PhoneNumberInput from "@/components/PhoneNumberInput";
 import { SignupTerms } from "@/constants/terms";
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useMemo, useState } from "react";
@@ -63,7 +64,9 @@ export default function TermsScreen() {
             source={allChecked ? CHECKBOX_ON_IMAGE : CHECKBOX_OFF_IMAGE}
             style={styles.allCheckBoxImage}
           />
-          <Text style={styles.allCheckText}>약관 전체 동의</Text>
+          <Text style={[styles.allCheckText, textStyles.title20_SB135]}>
+            약관 전체 동의
+          </Text>
         </TouchableOpacity>
       </View>
     );
@@ -91,7 +94,7 @@ export default function TermsScreen() {
               source={isChecked ? CHECKBOX_ON_IMAGE : CHECKBOX_OFF_IMAGE}
               style={styles.checkBoxImage}
             />
-            <Text style={styles.checkText}>
+            <Text style={[styles.checkText, textStyles.body16_M135]}>
               <Text>{required ? "(필수)" : "(선택)"}</Text> {content}
             </Text>
           </View>
@@ -114,7 +117,9 @@ export default function TermsScreen() {
         </View>
 
         {/* 전화번호 입력 */}
-        <Text style={styles.title}>{`전화번호를 \n입력해 주세요.`}</Text>
+        <Text
+          style={[styles.title, textStyles.title24_SB135]}
+        >{`전화번호를 \n입력해 주세요.`}</Text>
         <View style={{ marginBottom: 60 }}>
           <PhoneNumberInput onChangeText={handlePhoneNumberChange} />
         </View>
@@ -142,7 +147,7 @@ export default function TermsScreen() {
           disabled={!isNextButtonEnabled}
           onPress={() => router.push("/signup/verify")}
         >
-          <Text style={styles.nextText}>다음</Text>
+          <Text style={[styles.nextText, textStyles.title18_SB135]}>다음</Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -154,9 +159,6 @@ const styles = StyleSheet.create({
   inner: { flex: 1, position: "relative" },
 
   title: {
-    fontSize: 24,
-    fontWeight: "600",
-    lineHeight: 32.4,
     marginBottom: 28,
     color: colors.main,
   },
@@ -176,16 +178,10 @@ const styles = StyleSheet.create({
   },
 
   allCheckText: {
-    fontSize: 20,
-    fontWeight: 600,
     color: "#222",
-    lineHeight: 27,
   },
   checkText: {
-    fontSize: 16,
-    fontWeight: 500,
     color: "#888",
-    lineHeight: 21.6,
   },
 
   nextBtn: {
@@ -201,9 +197,6 @@ const styles = StyleSheet.create({
   },
   nextText: {
     color: colors.white,
-    fontSize: 18,
-    fontWeight: 600,
-    lineHeight: 24.3,
   },
   disabled: { opacity: 0.3 },
 });

--- a/TinyBite/app/(auth)/signup/terms.tsx
+++ b/TinyBite/app/(auth)/signup/terms.tsx
@@ -1,6 +1,7 @@
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
 import PhoneNumberInput from "@/components/PhoneNumberInput";
 import { SignupTerms } from "@/constants/terms";
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useMemo, useState } from "react";
@@ -157,7 +158,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     lineHeight: 32.4,
     marginBottom: 28,
-    color: "#FE870F",
+    color: colors.main,
   },
 
   checkRow: {
@@ -192,14 +193,14 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
     justifyContent: "center",
     alignItems: "center",
     paddingVertical: 16,
     borderRadius: 16,
   },
   nextText: {
-    color: "#ffffff",
+    color: colors.white,
     fontSize: 18,
     fontWeight: 600,
     lineHeight: 24.3,

--- a/TinyBite/app/(auth)/signup/terms.tsx
+++ b/TinyBite/app/(auth)/signup/terms.tsx
@@ -178,10 +178,10 @@ const styles = StyleSheet.create({
   },
 
   allCheckText: {
-    color: "#222",
+    color: colors.black,
   },
   checkText: {
-    color: "#888",
+    color: colors.gray[1],
   },
 
   nextBtn: {

--- a/TinyBite/app/(auth)/signup/verify.tsx
+++ b/TinyBite/app/(auth)/signup/verify.tsx
@@ -1,4 +1,5 @@
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useState } from "react";
@@ -93,7 +94,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     lineHeight: 32.4,
     marginBottom: 28,
-    color: "#FE870F",
+    color: colors.main,
   },
   verifyContainer: {
     flexDirection: "row",
@@ -108,7 +109,7 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "center",
     borderRadius: 16,
-    backgroundColor: "#ffffff",
+    backgroundColor: colors.white,
     borderWidth: 0,
     // 그림자 효과 (iOS)
     shadowColor: "#000",
@@ -133,14 +134,14 @@ const styles = StyleSheet.create({
   },
   resend: {
     flex: 1,
-    backgroundColor: "#FFEFD8",
+    backgroundColor: colors.sub,
     padding: 12,
     justifyContent: "center",
     alignItems: "center",
     borderRadius: 16,
   },
   resendText: {
-    color: "#FE870F",
+    color: colors.main,
     fontSize: 18,
     fontWeight: 600,
     lineHeight: 24.3,
@@ -156,14 +157,14 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
     justifyContent: "center",
     alignItems: "center",
     paddingVertical: 16,
     borderRadius: 16,
   },
   nextText: {
-    color: "#ffffff",
+    color: colors.white,
     fontSize: 18,
     fontWeight: 600,
     lineHeight: 24.3,

--- a/TinyBite/app/(auth)/signup/verify.tsx
+++ b/TinyBite/app/(auth)/signup/verify.tsx
@@ -1,5 +1,6 @@
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useState } from "react";
@@ -43,7 +44,9 @@ export default function VerifyScreen() {
         </View>
 
         {/* 인증 번호 입력 */}
-        <Text style={styles.title}>{`인증 번호를 \n입력해 주세요.`}</Text>
+        <Text
+          style={[styles.title, textStyles.title24_SB135]}
+        >{`인증 번호를 \n입력해 주세요.`}</Text>
         <View style={styles.verifyContainer}>
           <View style={styles.inputContainer}>
             <TextInput
@@ -52,7 +55,7 @@ export default function VerifyScreen() {
               placeholder="00000"
               placeholderTextColor="#888"
               keyboardType="numeric"
-              style={styles.input}
+              style={[styles.input, textStyles.title18_SB135]}
               maxLength={5}
               autoFocus={true}
             />
@@ -63,13 +66,17 @@ export default function VerifyScreen() {
           </View>
           <TouchableOpacity>
             <View style={styles.resend}>
-              <Text style={styles.resendText}>재발송</Text>
+              <Text style={[styles.resendText, textStyles.title18_SB135]}>
+                재발송
+              </Text>
             </View>
           </TouchableOpacity>
         </View>
 
         <View style={styles.timerContainer}>
-          <Text style={styles.timer}>남은 시간 3:00</Text>
+          <Text style={[styles.timer, textStyles.body15_SB135]}>
+            남은 시간 3:00
+          </Text>
         </View>
 
         {/* 다음 버튼 */}
@@ -78,7 +85,7 @@ export default function VerifyScreen() {
           disabled={!verified}
           onPress={() => router.push("/signup/nickname")}
         >
-          <Text style={styles.nextText}>다음</Text>
+          <Text style={[styles.nextText, textStyles.title18_SB135]}>다음</Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>
@@ -90,9 +97,6 @@ const styles = StyleSheet.create({
   inner: { flex: 1, position: "relative" },
 
   title: {
-    fontSize: 24,
-    fontWeight: "600",
-    lineHeight: 32.4,
     marginBottom: 28,
     color: colors.main,
   },
@@ -121,9 +125,6 @@ const styles = StyleSheet.create({
   },
   input: {
     flex: 1,
-    fontSize: 18,
-    fontWeight: 600,
-    lineHeight: 24.3,
     padding: 0,
     margin: 0,
   },
@@ -142,15 +143,12 @@ const styles = StyleSheet.create({
   },
   resendText: {
     color: colors.main,
-    fontSize: 18,
-    fontWeight: 600,
-    lineHeight: 24.3,
   },
 
   timerContainer: {
     flexDirection: "row",
   },
-  timer: { color: "#888", fontSize: 15, fontWeight: 600, lineHeight: 20.25 },
+  timer: { color: "#888" },
 
   nextBtn: {
     position: "absolute",
@@ -165,9 +163,6 @@ const styles = StyleSheet.create({
   },
   nextText: {
     color: colors.white,
-    fontSize: 18,
-    fontWeight: 600,
-    lineHeight: 24.3,
   },
   disabled: { opacity: 0.3 },
 });

--- a/TinyBite/app/(auth)/signup/verify.tsx
+++ b/TinyBite/app/(auth)/signup/verify.tsx
@@ -53,7 +53,7 @@ export default function VerifyScreen() {
               value={code}
               onChangeText={handleCodeChange}
               placeholder="00000"
-              placeholderTextColor="#888"
+              placeholderTextColor={colors.gray[1]}
               keyboardType="numeric"
               style={[styles.input, textStyles.title18_SB135]}
               maxLength={5}
@@ -148,7 +148,7 @@ const styles = StyleSheet.create({
   timerContainer: {
     flexDirection: "row",
   },
-  timer: { color: "#888" },
+  timer: { color: colors.gray[1] },
 
   nextBtn: {
     position: "absolute",

--- a/TinyBite/app/(tabs)/_layout.tsx
+++ b/TinyBite/app/(tabs)/_layout.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Tabs } from "expo-router";
 import { Image } from "react-native";
 
@@ -13,12 +14,9 @@ export default function TabsLayout() {
         tabBarActiveTintColor: PRIMARY_COLOR,
         tabBarInactiveTintColor: INACTIVE_COLOR,
         tabBarLabelStyle: {
-          fontSize: 13,
-          lineHeight: 17.5,
-          fontFamily: "Pretendard",
-          fontWeight: "600",
           textAlign: "center",
           marginTop: 4,
+          ...textStyles.body13_SB135,
         },
         tabBarStyle: {
           height: 92,

--- a/TinyBite/app/(tabs)/_layout.tsx
+++ b/TinyBite/app/(tabs)/_layout.tsx
@@ -1,8 +1,9 @@
+import { colors } from "@/styles/colors";
 import { Tabs } from "expo-router";
 import { Image } from "react-native";
 
-const PRIMARY_COLOR = "#FE870F";
-const INACTIVE_COLOR = "#AAAAAA";
+const PRIMARY_COLOR = colors.main;
+const INACTIVE_COLOR = colors.gray[2];
 
 export default function TabsLayout() {
   return (
@@ -23,7 +24,7 @@ export default function TabsLayout() {
           height: 92,
           paddingTop: 12,
           paddingBottom: 12,
-          backgroundColor: "#FFFFFF",
+          backgroundColor: colors.white,
           borderTopWidth: 0,
           shadowColor: "rgba(0,0,0,0.25)",
           shadowOpacity: 0.25,

--- a/TinyBite/app/(tabs)/chat.tsx
+++ b/TinyBite/app/(tabs)/chat.tsx
@@ -1,10 +1,11 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { StyleSheet, Text, View } from "react-native";
 
 export default function ChatScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>채팅</Text>
+      <Text style={[styles.title, textStyles.title24_SB135]}>채팅</Text>
     </View>
   );
 }
@@ -17,8 +18,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   title: {
-    fontSize: 24,
-    fontWeight: "700",
     marginBottom: 8,
   },
 });

--- a/TinyBite/app/(tabs)/chat.tsx
+++ b/TinyBite/app/(tabs)/chat.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { StyleSheet, Text, View } from "react-native";
 
 export default function ChatScreen() {
@@ -11,7 +12,7 @@ export default function ChatScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#FCFBFF",
+    backgroundColor: colors.background,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/TinyBite/app/(tabs)/index.tsx
+++ b/TinyBite/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import MainCard from "@/components/main/MainCard";
 import MainCategory from "@/components/main/MainCategory";
 import MainHeader from "@/components/main/MainHeader";
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 
 import { ScrollView, StyleSheet, View } from "react-native";
@@ -35,15 +36,15 @@ export default function HomeScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
   },
   container: {
     flex: 1,
-    backgroundColor: "#FCFBFF",
+    backgroundColor: colors.background,
   },
   scroll: {
     marginTop: 18,
-    backgroundColor: "#FCFBFF",
+    backgroundColor: colors.background,
   },
   listWrapper: {
     marginTop: 4,

--- a/TinyBite/app/(tabs)/profile.tsx
+++ b/TinyBite/app/(tabs)/profile.tsx
@@ -1,10 +1,11 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { StyleSheet, Text, View } from "react-native";
 
 export default function ProfileScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>내정보</Text>
+      <Text style={[styles.title, textStyles.title24_SB135]}>내정보</Text>
     </View>
   );
 }
@@ -17,8 +18,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   title: {
-    fontSize: 24,
-    fontWeight: "700",
     marginBottom: 8,
   },
 });

--- a/TinyBite/app/(tabs)/profile.tsx
+++ b/TinyBite/app/(tabs)/profile.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { StyleSheet, Text, View } from "react-native";
 
 export default function ProfileScreen() {
@@ -11,7 +12,7 @@ export default function ProfileScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#FCFBFF",
+    backgroundColor: colors.background,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/TinyBite/app/index.tsx
+++ b/TinyBite/app/index.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { useFonts } from "expo-font";
 import { router } from "expo-router";
 import { useEffect, useState } from "react";
@@ -69,7 +70,7 @@ export default function Index() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
     alignItems: "center",
     justifyContent: "center",
   },

--- a/TinyBite/app/main-card-detail.tsx
+++ b/TinyBite/app/main-card-detail.tsx
@@ -3,6 +3,7 @@ import MainCardDetailHostNote from "@/components/main/main-card-detail/MainCardD
 import MainCardDetailInfo from "@/components/main/main-card-detail/MainCardDetailInfo";
 import MainCardDetailPill from "@/components/main/main-card-detail/MainCardDetailPill";
 import MainCardDetailProductLink from "@/components/main/main-card-detail/MainCardDetailProductLink";
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 import React from "react";
 import {
@@ -150,7 +151,7 @@ const styles = StyleSheet.create({
   content: {
     marginTop: 220,
     width: "100%",
-    backgroundColor: "#FFFFFF",
+    backgroundColor: colors.white,
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
     paddingHorizontal: 20,
@@ -173,7 +174,7 @@ const styles = StyleSheet.create({
     alignSelf: "stretch",
     width: "100%",
     height: 4,
-    backgroundColor: "#F1F1F1",
+    backgroundColor: colors.gray[4],
     marginBottom: 16,
   },
 
@@ -181,7 +182,7 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 18,
     paddingHorizontal: 20,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: colors.white,
     alignItems: "center",
     justifyContent: "center",
     shadowColor: "#000000",
@@ -194,12 +195,12 @@ const styles = StyleSheet.create({
     width: "100%",
     paddingVertical: 16,
     borderRadius: 16,
-    backgroundColor: "#FE870F",
+    backgroundColor: colors.main,
     alignItems: "center",
     justifyContent: "center",
   },
   ctaText: {
-    color: "#FFFFFF",
+    color: colors.white,
     fontSize: 18,
     fontWeight: "600",
     fontFamily: "Pretendard",

--- a/TinyBite/app/main-card-detail.tsx
+++ b/TinyBite/app/main-card-detail.tsx
@@ -16,7 +16,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-const MainCardDetail = () => {
+export default function MainCardDetailScreen() {
   const router = useRouter();
 
   return (
@@ -102,9 +102,7 @@ const MainCardDetail = () => {
       </View>
     </View>
   );
-};
-
-export default MainCardDetail;
+}
 
 const styles = StyleSheet.create({
   container: { flex: 1, position: "relative" },

--- a/TinyBite/app/main-card-detail.tsx
+++ b/TinyBite/app/main-card-detail.tsx
@@ -4,6 +4,7 @@ import MainCardDetailInfo from "@/components/main/main-card-detail/MainCardDetai
 import MainCardDetailPill from "@/components/main/main-card-detail/MainCardDetailPill";
 import MainCardDetailProductLink from "@/components/main/main-card-detail/MainCardDetailProductLink";
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { useRouter } from "expo-router";
 import React from "react";
 import {
@@ -46,7 +47,9 @@ export default function MainCardDetailScreen() {
 
             <ScrollView style={styles.contentContainer} bounces={false}>
               <View style={[styles.content]}>
-                <Text style={styles.title}>후문 엽떡 나누실 분 ㅃㄹ</Text>
+                <Text style={[styles.title, textStyles.title20_B135]}>
+                  후문 엽떡 나누실 분 ㅃㄹ
+                </Text>
 
                 <View style={styles.pillsRow}>
                   <MainCardDetailPill type="delivery" />
@@ -96,7 +99,9 @@ export default function MainCardDetailScreen() {
         {/* 참여하기 버튼 */}
         <SafeAreaView style={styles.ctaContainer} edges={["bottom"]}>
           <TouchableOpacity style={styles.cta}>
-            <Text style={styles.ctaText}>5,000원으로 참여하기</Text>
+            <Text style={[styles.ctaText, textStyles.title18_SB135]}>
+              5,000원으로 참여하기
+            </Text>
           </TouchableOpacity>
         </SafeAreaView>
       </View>
@@ -156,10 +161,6 @@ const styles = StyleSheet.create({
     paddingVertical: 28,
   },
   title: {
-    fontSize: 20,
-    lineHeight: 27,
-    fontFamily: "Pretendard",
-    fontWeight: "700",
     color: "#000000",
     marginBottom: 8,
   },
@@ -199,9 +200,5 @@ const styles = StyleSheet.create({
   },
   ctaText: {
     color: colors.white,
-    fontSize: 18,
-    fontWeight: "600",
-    fontFamily: "Pretendard",
-    lineHeight: 24.3,
   },
 });

--- a/TinyBite/components/LocationSearchResult.tsx
+++ b/TinyBite/components/LocationSearchResult.tsx
@@ -1,3 +1,4 @@
+import { textStyles } from "@/styles/typography/textStyles";
 import {
   FlatList,
   StyleSheet,
@@ -30,7 +31,9 @@ const LocationSearchResult = () => {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{`'역삼동' 검색 결과`}</Text>
+      <Text
+        style={[styles.title, textStyles.body15_SB135]}
+      >{`'역삼동' 검색 결과`}</Text>
 
       <FlatList
         data={mockResultData}
@@ -50,7 +53,7 @@ interface ResultItemProps {
 const ResultItem = ({ text }: ResultItemProps) => {
   return (
     <TouchableOpacity>
-      <Text style={styles.resultText}>{text}</Text>
+      <Text style={[styles.resultText, textStyles.body16_M135]}>{text}</Text>
     </TouchableOpacity>
   );
 };
@@ -60,9 +63,6 @@ const styles = StyleSheet.create({
   title: {
     alignSelf: "stretch",
     color: "#888",
-    fontSize: 15,
-    fontWeight: 600,
-    lineHeight: 20.25,
     marginBottom: 24,
   },
 
@@ -76,9 +76,6 @@ const styles = StyleSheet.create({
   resultText: {
     alignSelf: "stretch",
     color: "#222",
-    fontSize: 16,
-    fontWeight: 500,
-    lineHeight: 21.6,
   },
 });
 

--- a/TinyBite/components/LocationSearchResult.tsx
+++ b/TinyBite/components/LocationSearchResult.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import {
   FlatList,
@@ -62,7 +63,7 @@ const styles = StyleSheet.create({
   container: { flex: 1, paddingVertical: 12 },
   title: {
     alignSelf: "stretch",
-    color: "#888",
+    color: colors.gray[1],
     marginBottom: 24,
   },
 
@@ -75,7 +76,7 @@ const styles = StyleSheet.create({
   },
   resultText: {
     alignSelf: "stretch",
-    color: "#222",
+    color: colors.black,
   },
 });
 

--- a/TinyBite/components/PaginationIndecatorHeader.tsx
+++ b/TinyBite/components/PaginationIndecatorHeader.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { useRouter } from "expo-router";
 import { Image, StyleSheet, TouchableOpacity, View } from "react-native";
 
@@ -6,8 +7,8 @@ interface PaginationIndecatorHeaderProps {
 }
 
 const DOT_SIZE = 8;
-const ACTIVE_COLOR = "#FE870F";
-const INACTIVE_COLOR = "#D9D9D9";
+const ACTIVE_COLOR = colors.main;
+const INACTIVE_COLOR = colors.gray[3];
 
 const PaginationIndecatorHeader = ({
   page,

--- a/TinyBite/components/PhoneNumberInput.tsx
+++ b/TinyBite/components/PhoneNumberInput.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import React, { useCallback, useState } from "react";
 import { StyleSheet, Text, TextInput, View } from "react-native";
@@ -80,7 +81,7 @@ const PhoneNumberInput: React.FC<PhoneNumberInputProps> = ({
         onChangeText={handleTextChange}
         value={displayValue}
         placeholder="010 - 1234 - 5678"
-        placeholderTextColor="#888"
+        placeholderTextColor={colors.gray[1]}
         keyboardType="numeric"
         maxLength={13} // 하이픈 포함
       />
@@ -93,7 +94,7 @@ const styles = StyleSheet.create({
     gap: 8,
     padding: 12,
     alignItems: "flex-start",
-    backgroundColor: "#fff",
+    backgroundColor: colors.white,
     borderRadius: 16,
     borderWidth: 0,
     // 그림자 효과 (iOS)
@@ -105,7 +106,7 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   label: {
-    color: "#888",
+    color: colors.gray[1],
   },
   input: {
     color: "#000",

--- a/TinyBite/components/PhoneNumberInput.tsx
+++ b/TinyBite/components/PhoneNumberInput.tsx
@@ -1,3 +1,4 @@
+import { textStyles } from "@/styles/typography/textStyles";
 import React, { useCallback, useState } from "react";
 import { StyleSheet, Text, TextInput, View } from "react-native";
 
@@ -71,11 +72,11 @@ const PhoneNumberInput: React.FC<PhoneNumberInputProps> = ({
   return (
     <View style={styles.container}>
       {/* 레이블 텍스트 */}
-      <Text style={styles.label}>{label}</Text>
+      <Text style={[styles.label, textStyles.body16_SB135]}>{label}</Text>
 
       {/* 입력 영역 */}
       <TextInput
-        style={styles.input}
+        style={[styles.input, textStyles.title18_SB135]}
         onChangeText={handleTextChange}
         value={displayValue}
         placeholder="010 - 1234 - 5678"
@@ -104,14 +105,9 @@ const styles = StyleSheet.create({
     elevation: 3,
   },
   label: {
-    fontSize: 16,
-    fontWeight: 600,
-    lineHeight: 21.6,
     color: "#888",
   },
   input: {
-    fontSize: 18,
-    fontWeight: "600",
     color: "#000",
     padding: 0,
     alignSelf: "stretch",

--- a/TinyBite/components/main/MainCard.tsx
+++ b/TinyBite/components/main/MainCard.tsx
@@ -51,7 +51,6 @@ const styles = StyleSheet.create({
     width: 90,
     height: 90,
     borderRadius: 16,
-    backgroundColor: "#F2F2F2",
   },
   cardBody: {
     flex: 1,
@@ -71,7 +70,7 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
   },
   badge: {
-    backgroundColor: "#FF8900",
+    backgroundColor: colors.main,
     padding: 0.5,
     width: 51,
     height: 26,

--- a/TinyBite/components/main/MainCard.tsx
+++ b/TinyBite/components/main/MainCard.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Image, Pressable, StyleSheet, Text, View } from "react-native";
 
 const MainCard = ({ onPress }: { onPress?: () => void }) => (
@@ -27,7 +28,7 @@ const styles = StyleSheet.create({
   card: {
     width: 362,
     height: 122,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: colors.white,
     borderRadius: 16,
     paddingHorizontal: 12,
     paddingVertical: 16,
@@ -84,7 +85,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   badgeText: {
-    color: "#FFFFFF",
+    color: colors.white,
     fontSize: 14,
     fontWeight: "700",
   },
@@ -92,7 +93,7 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 17.55,
     fontWeight: "600",
-    color: "#888888",
+    color: colors.gray[1],
     fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/MainCard.tsx
+++ b/TinyBite/components/main/MainCard.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, Pressable, StyleSheet, Text, View } from "react-native";
 
 const MainCard = ({ onPress }: { onPress?: () => void }) => (
@@ -9,14 +10,18 @@ const MainCard = ({ onPress }: { onPress?: () => void }) => (
     />
     <View style={styles.cardBody}>
       <View>
-        <Text style={styles.title}>후문 엽떡 나누실 분 ㅃㄹ</Text>
-        <Text style={styles.price}>5,000원</Text>
+        <Text style={[styles.title, textStyles.body16_B150]}>
+          후문 엽떡 나누실 분 ㅃㄹ
+        </Text>
+        <Text style={[styles.price, textStyles.body15_SB135]}>5,000원</Text>
       </View>
       <View style={styles.footerRow}>
         <View style={styles.badge}>
-          <Text style={styles.badgeText}>1/4명</Text>
+          <Text style={[styles.badgeText, textStyles.body13_SB135]}>1/4명</Text>
         </View>
-        <Text style={styles.meta}>10KM 이내 | 10분 전</Text>
+        <Text style={[styles.meta, textStyles.body13_SB135]}>
+          10KM 이내 | 10분 전
+        </Text>
       </View>
     </View>
   </Pressable>
@@ -54,19 +59,11 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
   },
   title: {
-    fontSize: 16,
-    lineHeight: 24,
-    fontWeight: "700",
     color: "#000000",
-    fontFamily: "Pretendard",
   },
   price: {
     marginTop: 6,
-    fontSize: 15,
-    lineHeight: 20.25,
-    fontWeight: "600",
     color: "#000000",
-    fontFamily: "Pretendard",
   },
   footerRow: {
     flexDirection: "row",
@@ -86,14 +83,8 @@ const styles = StyleSheet.create({
   },
   badgeText: {
     color: colors.white,
-    fontSize: 14,
-    fontWeight: "700",
   },
   meta: {
-    fontSize: 13,
-    lineHeight: 17.55,
-    fontWeight: "600",
     color: colors.gray[1],
-    fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/MainCategory.tsx
+++ b/TinyBite/components/main/MainCategory.tsx
@@ -1,9 +1,10 @@
+import { colors } from "@/styles/colors";
 import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
 
 const PRIMARY_COLOR = "#FE870F";
-const ACTIVE_BG = "#FFEFD8";
-const INACTIVE_BG = "#FFFFFF";
-const GRAY_TEXT = "#888888";
+const ACTIVE_BG = colors.sub;
+const INACTIVE_BG = colors.white;
+const GRAY_TEXT = colors.gray[1];
 
 const items = [
   { label: "전체", icon: null, active: true },

--- a/TinyBite/components/main/MainCategory.tsx
+++ b/TinyBite/components/main/MainCategory.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
 
 const PRIMARY_COLOR = "#FE870F";
@@ -42,6 +43,7 @@ const MainCategory = () => (
         <Text
           style={[
             styles.text,
+            textStyles.body16_SB135,
             active ? styles.textActive : styles.textInactive,
           ]}
         >
@@ -85,11 +87,7 @@ const styles = StyleSheet.create({
     backgroundColor: INACTIVE_BG,
   },
   text: {
-    fontSize: 16,
-    fontWeight: "600",
-    lineHeight: 21.6,
     textAlign: "center",
-    fontFamily: "Pretendard",
   },
   textActive: {
     color: PRIMARY_COLOR,

--- a/TinyBite/components/main/MainCategory.tsx
+++ b/TinyBite/components/main/MainCategory.tsx
@@ -2,7 +2,7 @@ import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
 
-const PRIMARY_COLOR = "#FE870F";
+const PRIMARY_COLOR = colors.main;
 const ACTIVE_BG = colors.sub;
 const INACTIVE_BG = colors.white;
 const GRAY_TEXT = colors.gray[1];

--- a/TinyBite/components/main/MainHeader.tsx
+++ b/TinyBite/components/main/MainHeader.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 const PRIMARY_COLOR = "#FE870F";
@@ -14,11 +15,11 @@ const MainHeader = () => (
             resizeMode="contain"
           />
         </View>
-        <Text style={styles.location}>역삼동</Text>
+        <Text style={[styles.location, textStyles.title20_B135]}>역삼동</Text>
       </View>
-      <Text style={styles.greetingLine1}>
+      <Text style={[styles.greetingLine1, textStyles.title20_B135]}>
         가짜대학생
-        <Text style={styles.greetingLine2}>
+        <Text style={[styles.greetingLine2, textStyles.title18_SB135]}>
           님,{"\n"}오늘은 무엇을 나눌까요 ?
         </Text>
       </Text>
@@ -60,11 +61,7 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   location: {
-    fontSize: 20,
-    lineHeight: 27,
-    fontWeight: "700",
     color: colors.white,
-    fontFamily: "Pretendard",
   },
   mainLogo: {
     width: 24,
@@ -78,18 +75,10 @@ const styles = StyleSheet.create({
     borderRadius: 6,
   },
   greetingLine1: {
-    fontSize: 20,
-    lineHeight: 30,
-    fontWeight: "700",
     color: colors.white,
-    fontFamily: "Pretendard",
   },
   greetingLine2: {
-    fontSize: 18,
-    lineHeight: 27,
-    fontWeight: "700",
     color: colors.white,
-    fontFamily: "Pretendard",
   },
   characterWrapper: {
     position: "absolute",

--- a/TinyBite/components/main/MainHeader.tsx
+++ b/TinyBite/components/main/MainHeader.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 const PRIMARY_COLOR = "#FE870F";
@@ -62,7 +63,7 @@ const styles = StyleSheet.create({
     fontSize: 20,
     lineHeight: 27,
     fontWeight: "700",
-    color: "#FFFFFF",
+    color: colors.white,
     fontFamily: "Pretendard",
   },
   mainLogo: {
@@ -80,14 +81,14 @@ const styles = StyleSheet.create({
     fontSize: 20,
     lineHeight: 30,
     fontWeight: "700",
-    color: "#FFFFFF",
+    color: colors.white,
     fontFamily: "Pretendard",
   },
   greetingLine2: {
     fontSize: 18,
     lineHeight: 27,
     fontWeight: "700",
-    color: "#FFFFFF",
+    color: colors.white,
     fontFamily: "Pretendard",
   },
   characterWrapper: {

--- a/TinyBite/components/main/MainHeader.tsx
+++ b/TinyBite/components/main/MainHeader.tsx
@@ -2,7 +2,7 @@ import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import { Image, StyleSheet, Text, View } from "react-native";
 
-const PRIMARY_COLOR = "#FE870F";
+const PRIMARY_COLOR = colors.main;
 
 const MainHeader = () => (
   <View style={styles.container}>

--- a/TinyBite/components/main/main-card-detail/MainCardDetailHost.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailHost.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 interface MainCardDetailHostProps {
@@ -75,7 +76,7 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 17.55,
     fontWeight: "600",
-    color: "#888888",
+    color: colors.gray[1],
     fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/main-card-detail/MainCardDetailHost.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailHost.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 interface MainCardDetailHostProps {
@@ -23,14 +24,16 @@ const MainCardDetailHost = ({
           resizeMode="cover"
         />
         <View>
-          <Text style={styles.hostName}>{name}</Text>
+          <Text style={[styles.hostName, textStyles.body15_SB135]}>{name}</Text>
           <View style={styles.hostMetaRow}>
             <Image
               source={require("@/assets/images/mainlist/detail/location-icon.png")}
               style={styles.hostMetaIcon}
               resizeMode="contain"
             />
-            <Text style={styles.hostMeta}>{location}</Text>
+            <Text style={[styles.hostMeta, textStyles.body13_SB135]}>
+              {location}
+            </Text>
           </View>
         </View>
       </View>
@@ -56,11 +59,7 @@ const styles = StyleSheet.create({
     height: 40,
   },
   hostName: {
-    fontSize: 15,
-    lineHeight: 20.25,
-    fontWeight: "600",
     color: "#000000",
-    fontFamily: "Pretendard",
   },
   hostMetaRow: {
     marginTop: 2,
@@ -73,10 +72,6 @@ const styles = StyleSheet.create({
     height: 18,
   },
   hostMeta: {
-    fontSize: 13,
-    lineHeight: 17.55,
-    fontWeight: "600",
     color: colors.gray[1],
-    fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/main-card-detail/MainCardDetailHostNote.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailHostNote.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 interface MainCardDetailHostNoteProps {
@@ -25,7 +26,7 @@ export default MainCardDetailHostNote;
 const styles = StyleSheet.create({
   noteBox: {
     width: "100%",
-    backgroundColor: "#FCFBFF",
+    backgroundColor: colors.background,
     borderRadius: 16,
     padding: 12,
     marginTop: 16,
@@ -39,7 +40,7 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 17.55,
     fontWeight: "600",
-    color: "#888888",
+    color: colors.gray[1],
     fontFamily: "Pretendard",
   },
   noteHeader: {
@@ -56,7 +57,7 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 19.5,
     fontWeight: "600",
-    color: "#222222",
+    color: colors.black,
     fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/main-card-detail/MainCardDetailHostNote.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailHostNote.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 interface MainCardDetailHostNoteProps {
@@ -14,9 +15,11 @@ const MainCardDetailHostNote = ({ body }: MainCardDetailHostNoteProps) => {
           style={styles.noteIcon}
           resizeMode="contain"
         />
-        <Text style={styles.noteTitle}>호스트의 한마디</Text>
+        <Text style={[styles.noteTitle, textStyles.body13_SB135]}>
+          호스트의 한마디
+        </Text>
       </View>
-      <Text style={styles.noteBody}>{body}</Text>
+      <Text style={[styles.noteBody, textStyles.body13_SB150]}>{body}</Text>
     </View>
   );
 };
@@ -37,11 +40,7 @@ const styles = StyleSheet.create({
     elevation: 4,
   },
   noteTitle: {
-    fontSize: 13,
-    lineHeight: 17.55,
-    fontWeight: "600",
     color: colors.gray[1],
-    fontFamily: "Pretendard",
   },
   noteHeader: {
     flexDirection: "row",
@@ -54,10 +53,6 @@ const styles = StyleSheet.create({
     height: 20,
   },
   noteBody: {
-    fontSize: 13,
-    lineHeight: 19.5,
-    fontWeight: "600",
     color: colors.black,
-    fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/main-card-detail/MainCardDetailInfo.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailInfo.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 type InfoType = "location" | "group" | "money";
@@ -74,7 +75,7 @@ const styles = StyleSheet.create({
     width: 44,
     height: 44,
     borderRadius: 22,
-    backgroundColor: "#FFEFD8",
+    backgroundColor: colors.sub,
     paddingHorizontal: 3,
     paddingVertical: 4,
     alignItems: "center",
@@ -88,7 +89,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 16.2,
     fontWeight: "500",
-    color: "#888888",
+    color: colors.gray[1],
     fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/main-card-detail/MainCardDetailInfo.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailInfo.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 type InfoType = "location" | "group" | "money";
@@ -40,8 +41,12 @@ const MainCardDetailInfo = ({ items }: MainCardDetailInfoProps) => {
               />
             </View>
             <View style={styles.infoBlock}>
-              <Text style={styles.infoTitle}>{item.title}</Text>
-              <Text style={styles.infoMeta}>{item.meta}</Text>
+              <Text style={[styles.infoTitle, textStyles.body16_SB135]}>
+                {item.title}
+              </Text>
+              <Text style={[styles.infoMeta, textStyles.body12_M135]}>
+                {item.meta}
+              </Text>
             </View>
           </View>
         ))}
@@ -65,11 +70,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   infoTitle: {
-    fontSize: 16,
-    lineHeight: 21.6,
-    fontWeight: "600",
     color: "#000000",
-    fontFamily: "Pretendard",
   },
   infoIconWrap: {
     width: 44,
@@ -86,10 +87,6 @@ const styles = StyleSheet.create({
     height: 32,
   },
   infoMeta: {
-    fontSize: 12,
-    lineHeight: 16.2,
-    fontWeight: "500",
     color: colors.gray[1],
-    fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/main-card-detail/MainCardDetailPill.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailPill.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 type PillType = "delivery" | "grocery" | "essentials" | "time";
@@ -66,7 +67,7 @@ const styles = StyleSheet.create({
   pillText: {
     fontSize: 12,
     fontWeight: "500",
-    color: "#888888",
+    color: colors.gray[1],
     fontFamily: "Pretendard",
   },
   pillIcon: {

--- a/TinyBite/components/main/main-card-detail/MainCardDetailPill.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailPill.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 type PillType = "delivery" | "grocery" | "essentials" | "time";
@@ -47,7 +48,9 @@ const MainCardDetailPill = ({ type, label }: MainCardDetailPillProps) => {
       {icon && (
         <Image source={icon} style={styles.pillIcon} resizeMode="contain" />
       )}
-      <Text style={styles.pillText}>{displayLabel}</Text>
+      <Text style={[styles.pillText, textStyles.body12_M135]}>
+        {displayLabel}
+      </Text>
     </View>
   );
 };
@@ -65,10 +68,7 @@ const styles = StyleSheet.create({
     borderRadius: 100,
   },
   pillText: {
-    fontSize: 12,
-    fontWeight: "500",
     color: colors.gray[1],
-    fontFamily: "Pretendard",
   },
   pillIcon: {
     width: 24,

--- a/TinyBite/components/main/main-card-detail/MainCardDetailProductLink.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailProductLink.tsx
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 interface MainCardDetailProductLinkProps {
@@ -42,7 +43,7 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     width: "100%",
     height: 110,
-    backgroundColor: "#FCFBFF",
+    backgroundColor: colors.background,
     borderRadius: 16,
     padding: 12,
     shadowColor: "#000000",
@@ -70,7 +71,7 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 17.55,
     fontWeight: "600",
-    color: "#222222",
+    color: colors.black,
     fontFamily: "Pretendard",
   },
   linkPhoto: {
@@ -87,14 +88,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 19.5,
     fontWeight: "600",
-    color: "#222222",
+    color: colors.black,
     fontFamily: "Pretendard",
   },
   linkUrl: {
     fontSize: 13,
     lineHeight: 17.55,
     fontWeight: "500",
-    color: "#888888",
+    color: colors.gray[1],
     fontFamily: "Pretendard",
   },
 });

--- a/TinyBite/components/main/main-card-detail/MainCardDetailProductLink.tsx
+++ b/TinyBite/components/main/main-card-detail/MainCardDetailProductLink.tsx
@@ -1,4 +1,5 @@
 import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
 import { Image, StyleSheet, Text, View } from "react-native";
 
 interface MainCardDetailProductLinkProps {
@@ -18,7 +19,9 @@ const MainCardDetailProductLink = ({
           style={styles.linkIcon}
           resizeMode="contain"
         />
-        <Text style={styles.linkLabel}>구매 예정 상품</Text>
+        <Text style={[styles.linkLabel, textStyles.body13_SB135]}>
+          구매 예정 상품
+        </Text>
       </View>
       <View style={styles.linkContent}>
         <Image
@@ -27,8 +30,12 @@ const MainCardDetailProductLink = ({
           resizeMode="cover"
         />
         <View style={styles.linkTexts}>
-          <Text style={styles.linkTitle}>{productTitle}</Text>
-          <Text style={styles.linkUrl}>{productUrl}</Text>
+          <Text style={[styles.linkTitle, textStyles.body13_SB150]}>
+            {productTitle}
+          </Text>
+          <Text style={[styles.linkUrl, textStyles.body13_M135]}>
+            {productUrl}
+          </Text>
         </View>
       </View>
     </View>
@@ -68,11 +75,7 @@ const styles = StyleSheet.create({
     height: 20,
   },
   linkLabel: {
-    fontSize: 13,
-    lineHeight: 17.55,
-    fontWeight: "600",
     color: colors.black,
-    fontFamily: "Pretendard",
   },
   linkPhoto: {
     width: 60,
@@ -85,17 +88,9 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   linkTitle: {
-    fontSize: 13,
-    lineHeight: 19.5,
-    fontWeight: "600",
     color: colors.black,
-    fontFamily: "Pretendard",
   },
   linkUrl: {
-    fontSize: 13,
-    lineHeight: 17.55,
-    fontWeight: "500",
     color: colors.gray[1],
-    fontFamily: "Pretendard",
   },
 });


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

<!-- title 규칙 → feat/#이슈번호: (작업 내용) -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#47 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

색상 및 텍스트 스타일을 디자인 시스템을 적용하여 변경했습니다. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

1. 스타일을 style 속성에서 지정하지 못할 때 방법

만약 아래 사진처럼 style 속성에서 대괄호로 지정하지 못한다면
<img width="463" height="58" alt="image" src="https://github.com/user-attachments/assets/fae09b4d-5e91-46fe-9688-123d748ea54f" />



아래 사진처럼 스프레드 문법 사용하시면 됩니다.
<img width="329" height="214" alt="image" src="https://github.com/user-attachments/assets/81738541-fe59-4955-b525-6ec2d1ea3f73" />

<br><br>

2. app 폴더의 페이지는 화살표 함수가 아닌 function으로 작성

제가 수정해뒀어요. 

❌ 
``` typescript
const MainCardDetail = () => {
};

export default MainCardDetail;
```


⭕ 
``` typescript
export default function MainCardDetailScreen() {
};
```

<br><br>

4. main-card-detail 페이지 디자인 놓친 부분

사진 위에 반투명으로 검은 그라데이션 들어간 걸 '딤드'라고 합니다.
서현님이 구현하신 코드에는 딤드가 없어요. 

<img width="626" height="306" alt="image" src="https://github.com/user-attachments/assets/85dd147b-6d3f-47b8-9976-1f19e25130d2" />
<img width="610" height="275" alt="image" src="https://github.com/user-attachments/assets/8f108a39-2d12-4c1a-b6a9-02a02b44de7a" />

상단에 검은 불투명 부분이 있고 없고가 확실히 차이가 있죠?
피그마에서 해당 레이어(사진에 빨간 동그라미) 껐다 켰다 확인하시면 더 명확할겁니다.

***이슈 새로 생성해서 해당 코드 구현해주세용***

추가로 디폴트 이미지도 딤드 없는 버전으로 다시 추가해주세요.
<img width="523" height="348" alt="image" src="https://github.com/user-attachments/assets/55b90567-f02d-4d65-a822-d9ea4b613a40" />

<br><br>

5. main-card-detail 페이지 backButton UI 구현 수정

지금 아래 사진처럼 이미지 자체에 bgColor가 있는데 코드에서도 추가로 bgColor 작성하셨죠? 그래서 구현된 backButton의 bgColor가 원래 디자인보다 진해졌어요. 

<img width="615" height="447" alt="image" src="https://github.com/user-attachments/assets/6068a83f-238a-4671-809d-b053cab55c98" />
<img width="512" height="179" alt="image" src="https://github.com/user-attachments/assets/00a5d06a-24ac-47eb-b0f6-690e15c66732" />

보통은 아이콘을 저렇게 통째로 저장하지 않아요..

아이콘 누르면 아래 사진처럼 컴포넌트로 등록된걸 확인할 수 있죠.
<img width="787" height="433" alt="image" src="https://github.com/user-attachments/assets/96a93b2a-48eb-46be-9355-d2fdad771473" />
<img width="251" height="148" alt="image" src="https://github.com/user-attachments/assets/ace8cbea-8609-4df8-aad6-4e6f5fd291b0" />

원래는 아이콘도 사이즈, 디자인별로 컴포넌트화 해주시는데 저희는 이것밖에 없으니까 이걸 쓸거에요. 

근데 피그마에 backButton인 < 아이콘 눌러보면 36x36 사이즈거든요, 근데 원본 < 아이콘은 24x24 사이즈라서 (현재는 벡터가 아니라 png로 아이콘을 쓰니까) 그냥 아래 사진처럼 피그마에서 저 아이콘 png로 export해서 쓸거에요. (배경 없이 아이콘만요)
<img width="176" height="187" alt="image" src="https://github.com/user-attachments/assets/964667e2-8033-47d4-981c-8a410706d6b5" />

그리고 저런 아이콘은 chevron이라고 해요.
제가 사용하고 있는 다른 chevron처럼 아래 사진처럼 규칙에 맞춰서 저장합니다. (png라서 크기까지 써줬어요. 아이콘을 크기별로 컴포넌트해서 small, medium, large 이름까지 정해주시는 디자이너분도 계시는데, 가이드가 없으니 이렇게 합니다)
<img width="173" height="120" alt="image" src="https://github.com/user-attachments/assets/7728e3bc-80c5-4615-89cc-9c0969edb484" />

아이콘 저장할 때는 같은 assets이 있는지 먼저 확인하고 작업합니다

***여기도 이슈 새로 생성해서 작업해주세용***

<br><br>

6. 코드 작성하실 때 자동완성 기능 사용하는건 작업시간도 단축하고 좋은데, 피그마 디자인과 값이 같은지 더블체크 꼭 해주세요!



<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
