### PR TITLE
Feat/64 로그인 정보 및 토큰 상태 관리

### DIFF
--- a/TinyBite/api/authApi.ts
+++ b/TinyBite/api/authApi.ts
@@ -1,4 +1,4 @@
-import { publicAxios } from "@/api/axios";
+import { privateAxios, publicAxios } from "@/api/axios";
 import { ENDPOINT } from "@/api/urls";
 import { CheckSms, LoginGoogle, SignupGoogle, UserCoords } from "@/types/auth";
 
@@ -36,4 +36,8 @@ export const getLocationName = async (coordsData: UserCoords) => {
     },
   });
   return res.data.data;
+};
+
+export const postLogout = async () => {
+  await privateAxios.post(ENDPOINT.AUTH.LOGOUT);
 };

--- a/TinyBite/api/authApi.ts
+++ b/TinyBite/api/authApi.ts
@@ -1,6 +1,7 @@
 import { privateAxios, publicAxios } from "@/api/axios";
 import { ENDPOINT } from "@/api/urls";
 import { CheckSms, LoginGoogle, SignupGoogle, UserCoords } from "@/types/auth";
+import * as SecureStore from "expo-secure-store";
 
 export const postLoginGoogle = async (loginData: LoginGoogle) => {
   const res = await publicAxios.post(ENDPOINT.AUTH.LOGIN_GOOGLE, loginData);
@@ -40,4 +41,12 @@ export const getLocationName = async (coordsData: UserCoords) => {
 
 export const postLogout = async () => {
   await privateAxios.post(ENDPOINT.AUTH.LOGOUT);
+};
+
+export const postRefresh = async () => {
+  const refreshToken = await SecureStore.getItemAsync("refreshToken");
+  const res = await privateAxios.post(ENDPOINT.AUTH.REFRESH, {
+    refreshToken: refreshToken,
+  });
+  return res.data.data;
 };

--- a/TinyBite/api/axios.ts
+++ b/TinyBite/api/axios.ts
@@ -1,4 +1,5 @@
 import { BASE_URL } from "@/api/urls";
+import { useAuthStore } from "@/stores/authStore";
 import axios from "axios";
 import * as SecureStore from "expo-secure-store";
 
@@ -50,11 +51,83 @@ privateAxios.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+// 토큰 갱신 중인지 확인하는 플래그
+let isRefreshing = false;
+
+// 토큰 갱신 중 대기하는 요청들을 저장하는 큐
+let failedQueue: {
+  resolve: (value?: any) => void;
+  reject: (reason?: any) => void;
+}[] = [];
+
+/**
+ * 대기 중인 모든 요청을 처리
+ * @param error 에러가 있으면 모든 요청을 reject
+ * @param token 성공하면 새 토큰으로 모든 요청을 resolve
+ */
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(token);
+    }
+  });
+
+  failedQueue = [];
+};
+
+/**
+ * 토큰 만료 처리
+ */
 privateAxios.interceptors.response.use(
   (response) => {
     return response;
   },
-  (error) => {
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401 에러이고 재시도하지 않은 요청인지 확인
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      const authStore = useAuthStore.getState();
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            return privateAxios(originalRequest);
+          })
+          .catch((err) => {
+            return Promise.reject(err);
+          });
+      }
+
+      // 토큰 갱신 시도
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const success = await authStore.refreshAccessToken();
+
+        if (success) {
+          const newAccessToken = await SecureStore.getItemAsync("accessToken");
+          processQueue(null, newAccessToken);
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          return privateAxios(originalRequest);
+        } else {
+          processQueue(error, null);
+          return Promise.reject(error);
+        }
+      } catch (refreshError) {
+        processQueue(refreshError, null);
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
     return Promise.reject(error);
   }
 );

--- a/TinyBite/api/axios.ts
+++ b/TinyBite/api/axios.ts
@@ -31,11 +31,20 @@ export const privateAxios = axios.create({
 });
 
 privateAxios.interceptors.request.use(
-  (config) => {
-    const accessToken = SecureStore.getItemAsync("accessToken");
+  async (config) => {
+    const accessToken = await SecureStore.getItemAsync("accessToken");
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
+
+    console.log(
+      "[API Request] >>",
+      config.baseURL,
+      config.method?.toUpperCase(),
+      config.headers,
+      config.url,
+      config.data
+    );
     return config;
   },
   (error) => Promise.reject(error)

--- a/TinyBite/api/urls.ts
+++ b/TinyBite/api/urls.ts
@@ -8,6 +8,7 @@ export const ENDPOINT = {
     SMS_CHECK: "/api/v1/auth/sms/check",
   },
   AUTH: {
+    LOGOUT: "/api/v1/auth/logout",
     SIGNUP_GOOGLE: "/api/v1/auth/google/signup",
     LOGIN_GOOGLE: "/api/v1/auth/google/login",
     NICKNAME_CHECK: "/api/v1/auth/nickname/check",

--- a/TinyBite/api/urls.ts
+++ b/TinyBite/api/urls.ts
@@ -8,6 +8,7 @@ export const ENDPOINT = {
     SMS_CHECK: "/api/v1/auth/sms/check",
   },
   AUTH: {
+    REFRESH: "/api/v1/auth/refresh",
     LOGOUT: "/api/v1/auth/logout",
     SIGNUP_GOOGLE: "/api/v1/auth/google/signup",
     LOGIN_GOOGLE: "/api/v1/auth/google/login",

--- a/TinyBite/app/(auth)/login/login.tsx
+++ b/TinyBite/app/(auth)/login/login.tsx
@@ -1,5 +1,6 @@
 import { postLoginGoogle } from "@/api/authApi";
 import { getCurrentUser, signIn, signOut } from "@/hooks/useGoogleAuth";
+import { useAuthStore } from "@/stores/authStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import { ApiError } from "@/types/api";
@@ -18,14 +19,22 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { useShallow } from "zustand/shallow";
 
 export default function LoginScreen() {
   const router = useRouter();
+
+  const { login } = useAuthStore(
+    useShallow((state) => ({
+      login: state.login,
+    }))
+  );
 
   const loginMutation = useMutation({
     mutationFn: postLoginGoogle,
     onSuccess: (data) => {
       if (data.signup) {
+        login(data);
         router.push("/(tabs)");
       } else {
         router.push("/(auth)/signup/terms");

--- a/TinyBite/app/(auth)/login/login.tsx
+++ b/TinyBite/app/(auth)/login/login.tsx
@@ -41,6 +41,11 @@ export default function LoginScreen() {
       }
     },
     onError: (error: AxiosError<ApiError>) => {
+      if (error.response?.data.code === "INVALID_TOKEN") {
+        SecureStore.deleteItemAsync("googleIdToken");
+        return;
+      }
+
       if (error.response?.data) {
         const message = getErrorMessage(error.response.data);
         console.error(message);

--- a/TinyBite/app/(auth)/login/login.tsx
+++ b/TinyBite/app/(auth)/login/login.tsx
@@ -1,6 +1,5 @@
 import { postLoginGoogle } from "@/api/authApi";
 import { getCurrentUser, signIn, signOut } from "@/hooks/useGoogleAuth";
-import { useSignupStore } from "@/stores/signupStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import { ApiError } from "@/types/api";
@@ -8,6 +7,7 @@ import { getErrorMessage } from "@/utils/getErrorMessage ";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useRouter } from "expo-router";
+import * as SecureStore from "expo-secure-store";
 import { StatusBar } from "expo-status-bar";
 import {
   Image,
@@ -18,16 +18,9 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useShallow } from "zustand/shallow";
 
 export default function LoginScreen() {
   const router = useRouter();
-
-  const { setGoogleIdToken } = useSignupStore(
-    useShallow((state) => ({
-      setGoogleIdToken: state.setGoogleIdToken,
-    }))
-  );
 
   const loginMutation = useMutation({
     mutationFn: postLoginGoogle,
@@ -60,7 +53,7 @@ export default function LoginScreen() {
     }
 
     if (idToken) {
-      setGoogleIdToken(idToken);
+      await SecureStore.setItemAsync("googleIdToken", idToken);
       await loginMutation.mutateAsync({
         idToken: idToken,
         platformType: Platform.OS.toUpperCase() as "ANDROID" | "IOS",

--- a/TinyBite/app/(auth)/signup/nickname.tsx
+++ b/TinyBite/app/(auth)/signup/nickname.tsx
@@ -44,7 +44,7 @@ export default function NicknameScreen() {
         if (error.response.data.code === "DUPLICATED_NICKNAME") {
           Toast.show({
             type: "basicToast",
-            props: { text: "올바른 URL 형식으로 입력해주세요." },
+            props: { text: "이미 사용 중인 닉네임이에요." },
             position: "bottom",
             bottomOffset: 98,
             visibilityTime: 2000,

--- a/TinyBite/app/(auth)/signup/region.tsx
+++ b/TinyBite/app/(auth)/signup/region.tsx
@@ -9,6 +9,7 @@ import { getErrorMessage } from "@/utils/getErrorMessage ";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useRouter } from "expo-router";
+import * as SecureStore from "expo-secure-store";
 import { StatusBar } from "expo-status-bar";
 import {
   Image,
@@ -27,7 +28,6 @@ export default function RegionScreen() {
   const { loading, refresh } = useUserCoords();
 
   const {
-    googleIdToken,
     phoneNumber,
     terms,
     nickname,
@@ -36,7 +36,6 @@ export default function RegionScreen() {
     resetSignupStore,
   } = useSignupStore(
     useShallow((state) => ({
-      googleIdToken: state.googleIdToken,
       phoneNumber: state.phoneNumber,
       terms: state.terms,
       nickname: state.nickname,
@@ -102,14 +101,20 @@ export default function RegionScreen() {
       (term) => terms[term]
     );
 
-    SignupMutation.mutate({
-      idToken: googleIdToken,
-      phone: phoneNumber,
-      nickname: nickname,
-      location: locationName,
-      platform: Platform.OS.toUpperCase() as "ANDROID" | "IOS",
-      agreedTerms: checkedTerms,
-    });
+    const googleIdToken = await SecureStore.getItemAsync("googleIdToken");
+    
+    if (googleIdToken) {
+      SignupMutation.mutate({
+        idToken: googleIdToken,
+        phone: phoneNumber,
+        nickname: nickname,
+        location: locationName,
+        platform: Platform.OS.toUpperCase() as "ANDROID" | "IOS",
+        agreedTerms: checkedTerms,
+      });
+    } else {
+      alert("googleIdToken이 필요합니다. 로그아웃 후 다시 로그인해주세요.");
+    }
   };
 
   return (

--- a/TinyBite/app/(auth)/signup/region.tsx
+++ b/TinyBite/app/(auth)/signup/region.tsx
@@ -1,6 +1,7 @@
 import { getLocationName, postSignupGoogle } from "@/api/authApi";
 import PaginationIndecatorHeader from "@/components/PaginationIndecatorHeader";
 import { useUserCoords } from "@/hooks/useUserCoords";
+import { useAuthStore } from "@/stores/authStore";
 import { TermCode, useSignupStore } from "@/stores/signupStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
@@ -45,6 +46,12 @@ export default function RegionScreen() {
     }))
   );
 
+  const { login } = useAuthStore(
+    useShallow((state) => ({
+      login: state.login,
+    }))
+  );
+
   const GetLocationNameMutation = useMutation({
     mutationFn: getLocationName,
     onSuccess: (data) => {},
@@ -64,6 +71,7 @@ export default function RegionScreen() {
     onSuccess: (data) => {
       console.log("postSignupGoogle >>", data);
       resetSignupStore();
+      login(data);
       router.replace("/(auth)/signup/complete");
     },
     onError: (error: AxiosError<ApiError>) => {
@@ -102,7 +110,7 @@ export default function RegionScreen() {
     );
 
     const googleIdToken = await SecureStore.getItemAsync("googleIdToken");
-    
+
     if (googleIdToken) {
       SignupMutation.mutate({
         idToken: googleIdToken,

--- a/TinyBite/app/(mypage)/setting.tsx
+++ b/TinyBite/app/(mypage)/setting.tsx
@@ -1,15 +1,45 @@
+import { postLogout } from "@/api/authApi";
 import ConfirmModal from "@/components/ConfirmModal";
+import { useAuthStore } from "@/stores/authStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
+import { ApiError } from "@/types/api";
+import { getErrorMessage } from "@/utils/getErrorMessage ";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useState } from "react";
 import { Image, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { useShallow } from "zustand/shallow";
 
 export default function SettingScreen() {
   const router = useRouter();
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+
+  const { logout } = useAuthStore(
+    useShallow((state) => ({
+      logout: state.logout,
+    }))
+  );
+
+  const logoutMutation = useMutation({
+    mutationFn: postLogout,
+    onSuccess: () => {
+      logout();
+      router.replace("/login/login");
+    },
+    onError: (error: AxiosError<ApiError>) => {
+      if (error.response?.data) {
+        const message = getErrorMessage(error.response.data);
+        console.error(message);
+      } else {
+        // 네트워크 에러 등
+        console.error("네트워크 연결을 확인해주세요.");
+      }
+    },
+  });
 
   return (
     <SafeAreaView style={styles.container}>
@@ -110,6 +140,7 @@ export default function SettingScreen() {
         onClose={() => setShowLogoutModal(false)}
         onConfirm={() => {
           // TODO: 로그아웃 로직 구현
+          logoutMutation.mutateAsync();
         }}
       />
     </SafeAreaView>

--- a/TinyBite/app/(mypage)/setting.tsx
+++ b/TinyBite/app/(mypage)/setting.tsx
@@ -28,7 +28,6 @@ export default function SettingScreen() {
     mutationFn: postLogout,
     onSuccess: () => {
       logout();
-      router.replace("/login/login");
     },
     onError: (error: AxiosError<ApiError>) => {
       if (error.response?.data) {
@@ -139,7 +138,6 @@ export default function SettingScreen() {
         confirmText="예"
         onClose={() => setShowLogoutModal(false)}
         onConfirm={() => {
-          // TODO: 로그아웃 로직 구현
           logoutMutation.mutateAsync();
         }}
       />

--- a/TinyBite/stores/authStore.ts
+++ b/TinyBite/stores/authStore.ts
@@ -1,0 +1,34 @@
+import { LoginRespone, UserProfile } from "@/types/auth";
+import { router } from "expo-router";
+import * as SecureStore from "expo-secure-store";
+import { create } from "zustand";
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  user: UserProfile | null;
+  login: (res: LoginRespone) => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isAuthenticated: false,
+  user: null,
+  login: async (res: LoginRespone) => {
+    await SecureStore.setItemAsync("accessToken", res.authResponse.accessToken);
+    await SecureStore.setItemAsync(
+      "refreshToken",
+      res.authResponse.refreshToken
+    );
+
+    set({ user: res.authResponse.user, isAuthenticated: true });
+  },
+  logout: async () => {
+    await SecureStore.deleteItemAsync("googleIdToken");
+    await SecureStore.deleteItemAsync("accessToken");
+    await SecureStore.deleteItemAsync("refreshToken");
+
+    set({ user: null, isAuthenticated: false });
+
+    router.replace("/login/login");
+  },
+}));

--- a/TinyBite/stores/authStore.ts
+++ b/TinyBite/stores/authStore.ts
@@ -1,3 +1,4 @@
+import { postRefresh } from "@/api/authApi";
 import { LoginRespone, UserProfile } from "@/types/auth";
 import { router } from "expo-router";
 import * as SecureStore from "expo-secure-store";
@@ -8,9 +9,10 @@ export interface AuthState {
   user: UserProfile | null;
   login: (res: LoginRespone) => void;
   logout: () => void;
+  refreshAccessToken: () => Promise<boolean>;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   isAuthenticated: false,
   user: null,
   login: async (res: LoginRespone) => {
@@ -30,5 +32,20 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ user: null, isAuthenticated: false });
 
     router.replace("/login/login");
+  },
+  refreshAccessToken: async (): Promise<boolean> => {
+    try {
+      const data = await postRefresh();
+
+      await SecureStore.setItemAsync("accessToken", data.accessToken);
+      await SecureStore.setItemAsync("refreshToken", data.refreshToken);
+      set({ user: data.user, isAuthenticated: true });
+
+      return true;
+    } catch (error) {
+      console.error("Token refresh failed:", error);
+      get().logout();
+      return false;
+    }
   },
 }));

--- a/TinyBite/stores/signupStore.ts
+++ b/TinyBite/stores/signupStore.ts
@@ -10,14 +10,12 @@ export enum TermCode {
 }
 
 export interface SignupStoreState {
-  googleIdToken: string;
   phoneNumber: string;
   terms: {
     [key in TermCode]: boolean;
   };
   nickname: string;
   locationName: string;
-  setGoogleIdToken: (token: string) => void;
   setPhoneNumber: (number: string) => void;
   toggleTerm: (term: TermCode) => void;
   checkAllEssentialsOnly: () => void;
@@ -29,7 +27,6 @@ export interface SignupStoreState {
 }
 
 export const useSignupStore = create<SignupStoreState>((set, get) => ({
-  googleIdToken: "",
   phoneNumber: "",
   nickname: "",
   locationName: "",
@@ -40,11 +37,6 @@ export const useSignupStore = create<SignupStoreState>((set, get) => ({
     PRIVACY_COLLECT: false,
     PRIVACY_PROVIDE: false,
     MARKETING_RECEIVE: false,
-  },
-  setGoogleIdToken: (token: string) => {
-    set(() => ({
-      googleIdToken: token,
-    }));
   },
   setPhoneNumber: (number: string) => {
     set(() => ({
@@ -110,7 +102,6 @@ export const useSignupStore = create<SignupStoreState>((set, get) => ({
   },
   resetSignupStore: () => {
     set(() => ({
-      googleIdToken: "",
       phoneNumber: "",
       nickname: "",
       locationName: "",

--- a/TinyBite/types/auth.ts
+++ b/TinyBite/types/auth.ts
@@ -21,3 +21,26 @@ export type UserCoords = {
   latitude: string;
   longitude: string;
 };
+
+export type LoginRespone = {
+  signup: boolean;
+  authResponse: {
+    accessToken: string;
+    refreshToken: string;
+    tokenType: string;
+    expiresIn: number;
+    user: UserProfile;
+  };
+};
+
+export type UserProfile = {
+  userId: number;
+  email: string;
+  nickname: string;
+  type: string;
+  status: string;
+  location: string;
+  phone: string;
+  createdAt: string;
+  isNewUser: boolean;
+};


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

<!-- title 규칙 → feat/#이슈번호: (작업 내용) -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#64 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

###  authStore 추가
`stores > authStore.ts`
- user
이 값을 참조해서 유저의 정보를 사용할 수 있습니다. 
- login 함수
SecureStore에 accessToken, refreshToken을 저장하고, authStore의 user에 유저 정보를 저장합니다. 
googleIdToken은 SecureStore에 별도로 저장해야합니다.
- logout 함수
SecureStore에 저장해둔 accessToken, refreshToken, googleIdToken을 삭제하고, authStore의 user 정보를 null로 설정합니다. 
이후 로그인 화면으로 replace합니다. 
- refreshAccessToken 함수
axios의 privateAxios 인터셉터에서 401 에러인 경우 해당 함수를 호출하여 accessToken과 refreshToken을 갱신합니다. 

### 로그아웃 모달에 logout 함수 연결
`app > (mypage) > settings.tsx`의 로그아웃 모달의 '확인 버튼' 클릭시 로그아웃 로직이 수행되도록 했습니다. 
기존 로그인 화면의 구글 소셜 로그아웃을 통한 '임시 로그아웃 버튼'은 삭제했습니다. 



<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
