### PR TITLE
Feat/78 파티 수정 api 연동

### DIFF
--- a/TinyBite/api/authApi.ts
+++ b/TinyBite/api/authApi.ts
@@ -1,7 +1,6 @@
 import { privateAxios, publicAxios } from "@/api/axios";
 import { ENDPOINT } from "@/api/urls";
 import { CheckSms, LoginGoogle, SignupGoogle, UserCoords } from "@/types/auth";
-import * as SecureStore from "expo-secure-store";
 
 export const postLoginGoogle = async (loginData: LoginGoogle) => {
   const res = await publicAxios.post(ENDPOINT.AUTH.LOGIN_GOOGLE, loginData);
@@ -41,12 +40,4 @@ export const getLocationName = async (coordsData: UserCoords) => {
 
 export const postLogout = async () => {
   await privateAxios.post(ENDPOINT.AUTH.LOGOUT);
-};
-
-export const postRefresh = async () => {
-  const refreshToken = await SecureStore.getItemAsync("refreshToken");
-  const res = await privateAxios.post(ENDPOINT.AUTH.REFRESH, {
-    refreshToken: refreshToken,
-  });
-  return res.data.data;
 };

--- a/TinyBite/api/axios.ts
+++ b/TinyBite/api/axios.ts
@@ -89,9 +89,9 @@ privateAxios.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    // 401 에러이고 재시도하지 않은 요청인지 확인
+    // 401, 403 에러이고 재시도하지 않은 요청인지 확인
     if (
-      error.response?.status === 401 &&
+      (error.response?.status === 401 || error.response?.status === 403) &&
       !originalRequest._retry &&
       !originalRequest.url?.includes("/refresh")
     ) {

--- a/TinyBite/api/axios.ts
+++ b/TinyBite/api/axios.ts
@@ -1,4 +1,4 @@
-import { BASE_URL } from "@/api/urls";
+import { BASE_URL, ENDPOINT } from "@/api/urls";
 import { useAuthStore } from "@/stores/authStore";
 import axios from "axios";
 import * as SecureStore from "expo-secure-store";
@@ -90,9 +90,11 @@ privateAxios.interceptors.response.use(
     const originalRequest = error.config;
 
     // 401 에러이고 재시도하지 않은 요청인지 확인
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      const authStore = useAuthStore.getState();
-
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.url?.includes("/refresh")
+    ) {
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
@@ -111,17 +113,23 @@ privateAxios.interceptors.response.use(
       isRefreshing = true;
 
       try {
-        const success = await authStore.refreshAccessToken();
+        const refreshToken = await SecureStore.getItemAsync("refreshToken");
+        const res = await publicAxios.post(ENDPOINT.AUTH.REFRESH, {
+          refreshToken: refreshToken,
+        });
+        const data = res.data.data;
 
-        if (success) {
-          const newAccessToken = await SecureStore.getItemAsync("accessToken");
-          processQueue(null, newAccessToken);
-          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-          return privateAxios(originalRequest);
-        } else {
-          processQueue(error, null);
-          return Promise.reject(error);
-        }
+        await SecureStore.setItemAsync("accessToken", data.accessToken);
+        await SecureStore.setItemAsync("refreshToken", data.refreshToken);
+        useAuthStore.setState({
+          user: data.user,
+          isAuthenticated: true,
+        });
+
+        const newAccessToken = await SecureStore.getItemAsync("accessToken");
+        processQueue(null, newAccessToken);
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return privateAxios(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError, null);
         return Promise.reject(refreshError);

--- a/TinyBite/api/axios.ts
+++ b/TinyBite/api/axios.ts
@@ -95,6 +95,9 @@ privateAxios.interceptors.response.use(
       !originalRequest._retry &&
       !originalRequest.url?.includes("/refresh")
     ) {
+      console.log("error.response?.status >>", error.response?.status);
+      console.log("긴 기다림 끝에 401 에러 뜸!!!!");
+
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
@@ -132,6 +135,7 @@ privateAxios.interceptors.response.use(
         return privateAxios(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError, null);
+        useAuthStore.getState().logout();
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;

--- a/TinyBite/api/partyApi.ts
+++ b/TinyBite/api/partyApi.ts
@@ -138,6 +138,6 @@ export const patchParty = async ({
 }: {
   partyId: number;
   body: EditedPartyInfo;
-}): Promise<void> => {
+}) => {
   await privateAxios.patch(ENDPOINT.PARTY.EDIT_PARTIES(partyId), body);
 };

--- a/TinyBite/api/partyApi.ts
+++ b/TinyBite/api/partyApi.ts
@@ -1,6 +1,7 @@
 import { Photo } from "@/stores/creatingPartyStore";
 import {
   CreatingPartyBody,
+  EditedPartyInfo,
   PartyDetail,
   PartyDetailParams,
   PartyListParams,
@@ -124,4 +125,19 @@ export const deleteParty = async (partyId: number): Promise<void> => {
     }
     throw error;
   }
+};
+
+/**
+ * 파티 수정 API
+ * @param partyId 수정할 파티 id
+ * @param body 수정할 파티 정보
+ */
+export const patchParty = async ({
+  partyId,
+  body,
+}: {
+  partyId: number;
+  body: EditedPartyInfo;
+}): Promise<void> => {
+  await privateAxios.patch(ENDPOINT.PARTY.EDIT_PARTIES(partyId), body);
 };

--- a/TinyBite/api/urls.ts
+++ b/TinyBite/api/urls.ts
@@ -21,6 +21,7 @@ export const ENDPOINT = {
     GET_PARTIES: "/api/parties",
     DETAIL: (partyId: number) => `/api/parties/${partyId}`,
     CREATE_PARTIES: "/api/parties",
+    EDIT_PARTIES: (partyId: number) => `/api/parties/${partyId}`,
   },
   FILE: {
     UPLOAD_FILE: "api/v1/file/upload",

--- a/TinyBite/app/party-detail/[id].tsx
+++ b/TinyBite/app/party-detail/[id].tsx
@@ -12,6 +12,7 @@ import PartyDetailProductLink from "@/components/main/party-detail/PartyDetailPr
 import { usePartyDetail } from "@/hooks/usePartyDetail";
 import { useUserCoords } from "@/hooks/useUserCoords";
 import { useAuthStore } from "@/stores/authStore";
+import { useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import { useQueryClient } from "@tanstack/react-query";
@@ -45,6 +46,9 @@ export default function PartyDetailScreen() {
 
   // 현재 로그인한 사용자 정보
   const user = useAuthStore((state) => state.user);
+  const setInitialPartyInfo = useEditPartyStore(
+    (state) => state.setInitialPartyInfo
+  );
 
   // 위치 정보 가져오기
   const { coords, refresh: fetchCoords } = useUserCoords();
@@ -61,6 +65,7 @@ export default function PartyDetailScreen() {
     data: partyDetail,
     isLoading,
     error,
+    isSuccess,
   } = usePartyDetail({
     partyId,
     latitude: coords?.latitude?.toString() || "",
@@ -106,6 +111,11 @@ export default function PartyDetailScreen() {
     );
   }
 
+  // 데이터를 성공적으로 받아왔을 시
+  if (isSuccess) {
+    setInitialPartyInfo(partyDetail);
+  }
+
   return (
     <>
       {/* 상태바 스타일: 헤더가 나타나면 dark, 아니면 light */}
@@ -131,6 +141,7 @@ export default function PartyDetailScreen() {
                 pathname: "/party/edit/[type]",
                 params: {
                   type: "GROCERY",
+                  mode: "edit",
                   allEditable: (
                     partyDetail.currentParticipants === 0
                   ).toString(),

--- a/TinyBite/app/party-detail/[id].tsx
+++ b/TinyBite/app/party-detail/[id].tsx
@@ -127,7 +127,15 @@ export default function PartyDetailScreen() {
         {partyDetail?.host.userId === user?.userId && (
           <PartyDetailMoreButton
             onEdit={() => {
-              // 수정 기능 구현
+              router.navigate({
+                pathname: "/party/edit/[type]",
+                params: {
+                  type: "GROCERY",
+                  allEditable: (
+                    partyDetail.currentParticipants === 0
+                  ).toString(),
+                },
+              });
             }}
             onDelete={async () => {
               try {

--- a/TinyBite/app/party/create/[type].tsx
+++ b/TinyBite/app/party/create/[type].tsx
@@ -177,7 +177,9 @@ export default function PartyCreateScreen() {
       totalPrice: Number(totalAmount),
       maxParticipants: numberOfPeople,
       pickupLocation: {
-        place: pickUpLocation,
+        place: pickUpLocation.place,
+        pickupLatitude: pickUpLocation.pickupLatitude,
+        pickupLongitude: pickUpLocation.pickupLongitude,
       },
       ...(photoStringList && { images: photoStringList }),
       ...(productLink && { productLink }),
@@ -242,7 +244,7 @@ export default function PartyCreateScreen() {
                 placeholder="예) 역삼역 1번 출구"
                 maxLength={30}
                 onChangeText={setPickUpLocation}
-                value={pickUpLocation}
+                value={pickUpLocation.place}
               />
             </View>
 

--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -1,4 +1,4 @@
-import { patchParty } from "@/api/partyApi";
+import { patchParty, postFile } from "@/api/partyApi";
 import AddPhotoButton from "@/components/create-party/AddPhotoButton";
 import NumberOfPeopleBox from "@/components/create-party/NumberOfPeopleBox";
 import PhotoItem from "@/components/create-party/PhotoItem";
@@ -10,6 +10,7 @@ import { Photo } from "@/stores/creatingPartyStore";
 import { PhotoUrl, useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
 import { ApiError } from "@/types/api";
+import { EditedPartyInfo } from "@/types/party";
 import { getErrorMessage } from "@/utils/getErrorMessage";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
@@ -17,6 +18,7 @@ import { router, useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { FlatList, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import Toast from "react-native-toast-message";
 import { useShallow } from "zustand/shallow";
 
 const PARTY_CONFIG = {
@@ -50,7 +52,10 @@ export default function PartyCreateScreen() {
     photos,
     title,
     totalPrice,
+    maxParticipants,
     pickupLocation,
+    latitude,
+    longitude,
     description,
     productLink,
     setPartyTitle,
@@ -65,7 +70,10 @@ export default function PartyCreateScreen() {
       photos: state.photos,
       title: state.title,
       totalPrice: state.totalPrice,
+      maxParticipants: state.maxParticipants,
       pickupLocation: state.pickupLocation,
+      latitude: state.latitude,
+      longitude: state.longitude,
       description: state.description,
       productLink: state.productLink,
       setPartyTitle: state.setPartyTitle,
@@ -76,6 +84,22 @@ export default function PartyCreateScreen() {
       resetEditParty: state.resetEditParty,
     }))
   );
+
+  const UploadFileMutation = useMutation({
+    mutationFn: postFile,
+    onSuccess: (data) => {
+      return data;
+    },
+    onError: (error: AxiosError<ApiError>) => {
+      if (error.response?.data) {
+        const message = getErrorMessage(error.response.data);
+        alert(message);
+        console.error(message);
+      } else {
+        console.error("네트워크 연결을 확인해주세요.");
+      }
+    },
+  });
 
   const EditPartyMutation = useMutation({
     mutationFn: patchParty,
@@ -98,8 +122,85 @@ export default function PartyCreateScreen() {
     return <PhotoItem id={item.id} imageUri={item.imageUri} />;
   };
 
+  const isValidLink = (str: string): boolean => {
+    const trimmed = str.trim();
+    try {
+      const url = new URL(trimmed);
+      return (
+        (url.protocol === "http:" || url.protocol === "https:") &&
+        !!url.hostname
+      );
+    } catch {
+      return false;
+    }
+  };
+
   const onClickEditParty = async () => {
-    // TODO: 파티 수정 로직 구현
+    if (productLink.isEdited && !isValidLink(productLink.value)) {
+      Toast.show({
+        type: "basicToast",
+        props: { text: "올바른 URL 형식으로 입력해주세요." },
+        position: "bottom",
+        bottomOffset: 133,
+        visibilityTime: 2000,
+      });
+      return;
+    }
+
+    try {
+      // 1. 새로 추가된 사진들만 필터링
+      const newPhotos = photos.filter(
+        (photo): photo is Photo => "mimeType" in photo
+      );
+
+      // 2. 새 사진들 업로드
+      let uploadedImageUrls: string[] = [];
+      if (newPhotos.length > 0) {
+        const uploadResults = await UploadFileMutation.mutateAsync(newPhotos);
+        uploadedImageUrls = uploadResults;
+      }
+
+      // 3. 전체 이미지 URL 배열 생성 (순서 유지)
+      let uploadIndex = 0;
+      const allImageUrls = photos.map((photo) => {
+        if ("mimeType" in photo) {
+          // Photo 타입 -> 업로드된 URL 사용
+          return uploadedImageUrls[uploadIndex++];
+        } else {
+          // PhotoUrl 타입 -> 기존 imageUri 사용
+          return photo.imageUri;
+        }
+      });
+
+      const body: EditedPartyInfo = {
+        // 필수 필드
+        images: allImageUrls,
+        description: description,
+        pickupLocation: pickupLocation.value,
+        latitude: latitude.value,
+        longitude: longitude.value,
+      };
+
+      if (title.isEdited) {
+        body.title = title.value;
+      }
+      if (totalPrice.isEdited) {
+        body.totalPrice = Number(totalPrice.value);
+      }
+      if (maxParticipants.isEdited) {
+        body.maxParticipants = maxParticipants.value;
+      }
+      if (productLink.isEdited) {
+        body.productLink = productLink.value;
+      }
+
+      await EditPartyMutation.mutateAsync({
+        partyId: partyId,
+        body: body,
+      });
+    } catch (error) {
+      console.error("파티 수정 중 오류:", error);
+    }
   };
 
   return (

--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -1,0 +1,209 @@
+import AddPhotoButton from "@/components/create-party/AddPhotoButton";
+import NumberOfPeopleBox from "@/components/create-party/NumberOfPeopleBox";
+import PhotoItem from "@/components/create-party/PhotoItem";
+import SubTitle from "@/components/create-party/SubTitle";
+import TextInputBox from "@/components/create-party/TextInputBox";
+import CreatePartyPageHeader from "@/components/CreatePartyPageHeader";
+import GlobalButton from "@/components/GlobalButton";
+import { Photo, useCreatingPartyStore } from "@/stores/creatingPartyStore";
+import { colors } from "@/styles/colors";
+import { useLocalSearchParams } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+import { FlatList, ScrollView, StyleSheet, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useShallow } from "zustand/shallow";
+
+const PARTY_CONFIG = {
+  DELIVERY: {
+    showProductLink: false,
+    titlePlaceholder: "예) 엽떡 매운맛 같이 드실 분",
+  },
+  GROCERY: {
+    showProductLink: true,
+    titlePlaceholder: "예) 코스트코 베이글 나누실 분",
+  },
+  HOUSEHOLD: {
+    showProductLink: true,
+    titlePlaceholder: "예) 코스트코 베이글 나누실 분",
+  },
+} as const;
+
+export default function PartyCreateScreen() {
+  const { type } = useLocalSearchParams<{
+    type: "DELIVERY" | "GROCERY" | "HOUSEHOLD";
+  }>();
+  const { allEditable } = useLocalSearchParams<{
+    allEditable?: string;
+  }>();
+
+  const config = PARTY_CONFIG[type];
+  const isAllEditable = allEditable === "true";
+
+  const {
+    photos,
+    partyTitle,
+    totalAmount,
+    numberOfPeople,
+    pickUpLocation,
+    detailedDescription,
+    productLink,
+    setPartyTitle,
+    setTotalAmount,
+    setPickUpLocation,
+    setDetailedDescription,
+    setProductLink,
+    resetCreateParty,
+  } = useCreatingPartyStore(
+    useShallow((state) => ({
+      photos: state.photos,
+      partyTitle: state.partyTitle,
+      totalAmount: state.totalAmount,
+      numberOfPeople: state.numberOfPeople,
+      pickUpLocation: state.pickUpLocation,
+      detailedDescription: state.detailedDescription,
+      productLink: state.productLink,
+      setPartyTitle: state.setPartyTitle,
+      setTotalAmount: state.setTotalAmount,
+      setPickUpLocation: state.setPickUpLocation,
+      setDetailedDescription: state.setDetailedDescription,
+      setProductLink: state.setProductLink,
+      resetCreateParty: state.resetCreateParty,
+    }))
+  );
+
+  const renderItem = ({ item }: { item: Photo }) => {
+    return <PhotoItem id={item.id} imageUri={item.imageUri} />;
+  };
+
+  const onClickEditParty = async () => {
+    // TODO: 파티 수정 로직 구현
+  };
+
+  return (
+    <>
+      <StatusBar style="dark" />
+
+      <View style={styles.container}>
+        <CreatePartyPageHeader title="파티 수정" />
+
+        <ScrollView style={styles.contentContainer}>
+          <SafeAreaView style={styles.contentInner} edges={["bottom"]}>
+            <View style={styles.section}>
+              <SubTitle subTitle="사진 등록" isPic />
+              <View style={styles.photoContainer}>
+                <AddPhotoButton />
+                <FlatList
+                  data={photos}
+                  renderItem={renderItem}
+                  keyExtractor={(item) => item.id.toString()}
+                  horizontal={true}
+                  contentContainerStyle={{ gap: 8 }}
+                />
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <SubTitle subTitle="파티 제목" caption="(메뉴명)" />
+              <TextInputBox
+                placeholder={config.titlePlaceholder}
+                maxLength={30}
+                onChangeText={setPartyTitle}
+                value={partyTitle}
+                isEditable={isAllEditable}
+              />
+            </View>
+
+            <View style={styles.section}>
+              <SubTitle subTitle="예상 총 주문 금액" />
+              <TextInputBox
+                placeholder="0"
+                isAmount
+                onChangeText={setTotalAmount}
+                value={totalAmount}
+                isEditable={isAllEditable}
+              />
+            </View>
+
+            <View style={styles.section}>
+              <SubTitle subTitle="모집 인원" caption="(나 포함)" />
+              <NumberOfPeopleBox isDisabled={isAllEditable} />
+            </View>
+
+            <View style={styles.section}>
+              <SubTitle subTitle="수령 장소" />
+              <TextInputBox
+                iconType="location"
+                placeholder="예) 역삼역 1번 출구"
+                maxLength={30}
+                onChangeText={setPickUpLocation}
+                value={pickUpLocation}
+                isEditable={isAllEditable}
+              />
+            </View>
+
+            <View style={styles.section}>
+              <SubTitle subTitle="상세 설명" />
+              <TextInputBox
+                placeholder="추가로 전달 할 내용이 있다면 적어주세요."
+                maxLength={60}
+                onChangeText={setDetailedDescription}
+                value={detailedDescription}
+              />
+            </View>
+
+            {config.showProductLink && (
+              <View style={styles.section}>
+                <SubTitle subTitle="상품 링크" />
+                <TextInputBox
+                  iconType="link"
+                  placeholder="구매할 상품의 URL을 입력하세요."
+                  onChangeText={setProductLink}
+                  value={productLink}
+                  isEditable={isAllEditable}
+                />
+              </View>
+            )}
+          </SafeAreaView>
+        </ScrollView>
+
+        <SafeAreaView style={styles.createButtonContainer} edges={["bottom"]}>
+          <GlobalButton onClick={onClickEditParty} text="완료" />
+        </SafeAreaView>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  contentContainer: {
+    flex: 1,
+  },
+  contentInner: {
+    flex: 1,
+    gap: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+  },
+  section: {
+    gap: 12,
+  },
+  photoContainer: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  createButtonContainer: {
+    paddingTop: 12,
+    paddingHorizontal: 20,
+    paddingBottom: 17,
+    backgroundColor: "#fff",
+    shadowColor: "rgba(0, 0, 0, 0.25)",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+});

--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -5,7 +5,8 @@ import SubTitle from "@/components/create-party/SubTitle";
 import TextInputBox from "@/components/create-party/TextInputBox";
 import CreatePartyPageHeader from "@/components/CreatePartyPageHeader";
 import GlobalButton from "@/components/GlobalButton";
-import { Photo, useCreatingPartyStore } from "@/stores/creatingPartyStore";
+import { Photo } from "@/stores/creatingPartyStore";
+import { PhotoUrl, useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
 import { useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
@@ -40,38 +41,36 @@ export default function PartyCreateScreen() {
   const isAllEditable = allEditable === "true";
 
   const {
+    partyId,
     photos,
-    partyTitle,
-    totalAmount,
-    numberOfPeople,
-    pickUpLocation,
-    detailedDescription,
+    title,
+    totalPrice,
+    pickupLocation,
+    description,
     productLink,
     setPartyTitle,
     setTotalAmount,
     setPickUpLocation,
     setDetailedDescription,
     setProductLink,
-    resetCreateParty,
-  } = useCreatingPartyStore(
+  } = useEditPartyStore(
     useShallow((state) => ({
+      partyId: state.partyId,
       photos: state.photos,
-      partyTitle: state.partyTitle,
-      totalAmount: state.totalAmount,
-      numberOfPeople: state.numberOfPeople,
-      pickUpLocation: state.pickUpLocation,
-      detailedDescription: state.detailedDescription,
+      title: state.title,
+      totalPrice: state.totalPrice,
+      pickupLocation: state.pickupLocation,
+      description: state.description,
       productLink: state.productLink,
       setPartyTitle: state.setPartyTitle,
       setTotalAmount: state.setTotalAmount,
       setPickUpLocation: state.setPickUpLocation,
       setDetailedDescription: state.setDetailedDescription,
       setProductLink: state.setProductLink,
-      resetCreateParty: state.resetCreateParty,
     }))
   );
 
-  const renderItem = ({ item }: { item: Photo }) => {
+  const renderItem = ({ item }: { item: Photo | PhotoUrl }) => {
     return <PhotoItem id={item.id} imageUri={item.imageUri} />;
   };
 
@@ -108,7 +107,7 @@ export default function PartyCreateScreen() {
                 placeholder={config.titlePlaceholder}
                 maxLength={30}
                 onChangeText={setPartyTitle}
-                value={partyTitle}
+                value={title.value}
                 isEditable={isAllEditable}
               />
             </View>
@@ -119,7 +118,7 @@ export default function PartyCreateScreen() {
                 placeholder="0"
                 isAmount
                 onChangeText={setTotalAmount}
-                value={totalAmount}
+                value={totalPrice.value}
                 isEditable={isAllEditable}
               />
             </View>
@@ -136,7 +135,7 @@ export default function PartyCreateScreen() {
                 placeholder="예) 역삼역 1번 출구"
                 maxLength={30}
                 onChangeText={setPickUpLocation}
-                value={pickUpLocation}
+                value={pickupLocation.value}
                 isEditable={isAllEditable}
               />
             </View>
@@ -147,7 +146,7 @@ export default function PartyCreateScreen() {
                 placeholder="추가로 전달 할 내용이 있다면 적어주세요."
                 maxLength={60}
                 onChangeText={setDetailedDescription}
-                value={detailedDescription}
+                value={description}
               />
             </View>
 
@@ -158,7 +157,7 @@ export default function PartyCreateScreen() {
                   iconType="link"
                   placeholder="구매할 상품의 URL을 입력하세요."
                   onChangeText={setProductLink}
-                  value={productLink}
+                  value={productLink.value}
                   isEditable={isAllEditable}
                 />
               </View>

--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -54,8 +54,6 @@ export default function PartyCreateScreen() {
     totalPrice,
     maxParticipants,
     pickupLocation,
-    latitude,
-    longitude,
     description,
     productLink,
     setPartyTitle,
@@ -72,8 +70,6 @@ export default function PartyCreateScreen() {
       totalPrice: state.totalPrice,
       maxParticipants: state.maxParticipants,
       pickupLocation: state.pickupLocation,
-      latitude: state.latitude,
-      longitude: state.longitude,
       description: state.description,
       productLink: state.productLink,
       setPartyTitle: state.setPartyTitle,
@@ -176,9 +172,11 @@ export default function PartyCreateScreen() {
         // 필수 필드
         images: allImageUrls,
         description: description,
-        pickupLocation: pickupLocation.value,
-        latitude: latitude.value,
-        longitude: longitude.value,
+        pickupLocation: {
+          place: pickupLocation.place,
+          pickupLatitude: pickupLocation.pickupLatitude,
+          pickupLongitude: pickupLocation.pickupLongitude,
+        },
       };
 
       if (title.isEdited) {
@@ -260,7 +258,7 @@ export default function PartyCreateScreen() {
                 placeholder="예) 역삼역 1번 출구"
                 maxLength={30}
                 onChangeText={setPickUpLocation}
-                value={pickupLocation.value}
+                value={pickupLocation.place}
                 isEditable={isAllEditable}
               />
             </View>

--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -1,3 +1,4 @@
+import { patchParty } from "@/api/partyApi";
 import AddPhotoButton from "@/components/create-party/AddPhotoButton";
 import NumberOfPeopleBox from "@/components/create-party/NumberOfPeopleBox";
 import PhotoItem from "@/components/create-party/PhotoItem";
@@ -8,7 +9,11 @@ import GlobalButton from "@/components/GlobalButton";
 import { Photo } from "@/stores/creatingPartyStore";
 import { PhotoUrl, useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
-import { useLocalSearchParams } from "expo-router";
+import { ApiError } from "@/types/api";
+import { getErrorMessage } from "@/utils/getErrorMessage";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { router, useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { FlatList, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -53,6 +58,7 @@ export default function PartyCreateScreen() {
     setPickUpLocation,
     setDetailedDescription,
     setProductLink,
+    resetEditParty,
   } = useEditPartyStore(
     useShallow((state) => ({
       partyId: state.partyId,
@@ -67,8 +73,26 @@ export default function PartyCreateScreen() {
       setPickUpLocation: state.setPickUpLocation,
       setDetailedDescription: state.setDetailedDescription,
       setProductLink: state.setProductLink,
+      resetEditParty: state.resetEditParty,
     }))
   );
+
+  const EditPartyMutation = useMutation({
+    mutationFn: patchParty,
+    onSuccess: (data) => {
+      resetEditParty();
+      router.replace(`/party-detail/${partyId}`);
+    },
+    onError: (error: AxiosError<ApiError>) => {
+      if (error.response?.data) {
+        const message = getErrorMessage(error.response.data);
+        alert(message);
+        console.error(message);
+      } else {
+        console.error("네트워크 연결을 확인해주세요.");
+      }
+    },
+  });
 
   const renderItem = ({ item }: { item: Photo | PhotoUrl }) => {
     return <PhotoItem id={item.id} imageUri={item.imageUri} />;

--- a/TinyBite/components/create-party/AddPhotoButton.tsx
+++ b/TinyBite/components/create-party/AddPhotoButton.tsx
@@ -1,14 +1,28 @@
 import { useCreatingPartyStore } from "@/stores/creatingPartyStore";
+import { useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
 import * as ImagePicker from "expo-image-picker";
+import { useLocalSearchParams } from "expo-router";
 import { Alert, Image, StyleSheet, Text, TouchableOpacity } from "react-native";
 import { useShallow } from "zustand/shallow";
 
 const CAMERA_ICON = require("@/assets/images/camera-24-gray.png");
 
 const AddPhotoButton = () => {
-  const { addPhoto, photos } = useCreatingPartyStore(
+  const { mode } = useLocalSearchParams<{
+    mode?: string;
+  }>();
+  const isEditingMode = mode === "edit";
+
+  const { addPhoto: createAddPhoto, photos: createPhotos } =
+    useCreatingPartyStore(
+      useShallow((state) => ({
+        addPhoto: state.addPhoto,
+        photos: state.photos,
+      }))
+    );
+  const { addPhoto: editAddPhoto, photos: editPhotos } = useEditPartyStore(
     useShallow((state) => ({
       addPhoto: state.addPhoto,
       photos: state.photos,
@@ -27,7 +41,8 @@ const AddPhotoButton = () => {
       return;
     }
 
-    if (photos.length >= 5) return;
+    if (isEditingMode ? editPhotos.length >= 5 : createPhotos.length >= 5)
+      return;
 
     let result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ["images"],
@@ -37,11 +52,20 @@ const AddPhotoButton = () => {
 
     if (!result.canceled) {
       const asset = result.assets[0];
-      addPhoto(
-        asset.uri,
-        asset.mimeType || "image/jpeg",
-        asset.fileName || "photo"
-      );
+
+      if (isEditingMode) {
+        editAddPhoto(
+          asset.uri,
+          asset.mimeType || "image/jpeg",
+          asset.fileName || "photo"
+        );
+      } else {
+        createAddPhoto(
+          asset.uri,
+          asset.mimeType || "image/jpeg",
+          asset.fileName || "photo"
+        );
+      }
     }
   };
 

--- a/TinyBite/components/create-party/NumberOfPeopleBox.tsx
+++ b/TinyBite/components/create-party/NumberOfPeopleBox.tsx
@@ -1,17 +1,26 @@
 import { useCreatingPartyStore } from "@/stores/creatingPartyStore";
+import { useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
+import { useLocalSearchParams } from "expo-router";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useShallow } from "zustand/shallow";
 
 const MINUS_ICON = require("@/assets/images/minus-24-gray.png");
 const PLUS_ICON = require("@/assets/images/plus-24-gray.png");
+const MIN = 2;
+const MAX = 10;
 
 interface NumberOfPeopleBoxProps {
   isDisabled?: boolean;
 }
 
 const NumberOfPeopleBox = ({ isDisabled = true }: NumberOfPeopleBoxProps) => {
+  const { mode } = useLocalSearchParams<{
+    mode?: string;
+  }>();
+  const isEditingMode = mode === "edit";
+
   const { numberOfPeople, setNumberOfPeople } = useCreatingPartyStore(
     useShallow((state) => ({
       numberOfPeople: state.numberOfPeople,
@@ -19,15 +28,39 @@ const NumberOfPeopleBox = ({ isDisabled = true }: NumberOfPeopleBoxProps) => {
     }))
   );
 
+  const { maxParticipants, setMaxParticipants } = useEditPartyStore(
+    useShallow((state) => ({
+      maxParticipants: state.maxParticipants,
+      setMaxParticipants: state.setMaxParticipants,
+    }))
+  );
+
+  const getCurrentValue = () =>
+    isEditingMode ? maxParticipants?.value : numberOfPeople;
+
+  const setCurrentValue = (value: number) => {
+    if (isEditingMode) {
+      setMaxParticipants(value);
+    } else {
+      setNumberOfPeople(value);
+    }
+  };
+
   const handleClickMinus = () => {
-    if (numberOfPeople > 2) {
-      setNumberOfPeople(numberOfPeople - 1);
+    const current = getCurrentValue();
+    if (current === undefined) return;
+
+    if (current > MIN) {
+      setCurrentValue(current - 1);
     }
   };
 
   const handleClickPlus = () => {
-    if (numberOfPeople < 10) {
-      setNumberOfPeople(numberOfPeople + 1);
+    const current = getCurrentValue();
+    if (current === undefined) return;
+
+    if (current < MAX) {
+      setCurrentValue(current + 1);
     }
   };
 
@@ -54,7 +87,7 @@ const NumberOfPeopleBox = ({ isDisabled = true }: NumberOfPeopleBoxProps) => {
               { color: isDisabled ? colors.main : colors.gray[1] },
             ]}
           >
-            {numberOfPeople}
+            {isEditingMode ? maxParticipants.value : numberOfPeople}
           </Text>
           <Text style={[styles.textUnit, textStyles.body16_SB135]}>명</Text>
         </View>

--- a/TinyBite/components/create-party/NumberOfPeopleBox.tsx
+++ b/TinyBite/components/create-party/NumberOfPeopleBox.tsx
@@ -7,7 +7,11 @@ import { useShallow } from "zustand/shallow";
 const MINUS_ICON = require("@/assets/images/minus-24-gray.png");
 const PLUS_ICON = require("@/assets/images/plus-24-gray.png");
 
-const NumberOfPeopleBox = () => {
+interface NumberOfPeopleBoxProps {
+  isDisabled?: boolean;
+}
+
+const NumberOfPeopleBox = ({ isDisabled = true }: NumberOfPeopleBoxProps) => {
   const { numberOfPeople, setNumberOfPeople } = useCreatingPartyStore(
     useShallow((state) => ({
       numberOfPeople: state.numberOfPeople,
@@ -28,17 +32,28 @@ const NumberOfPeopleBox = () => {
   };
 
   return (
-    <View style={styles.container}>
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: isDisabled ? colors.white : colors.gray[3] },
+      ]}
+    >
       <View style={styles.inner}>
         <TouchableOpacity
           style={styles.buttonContainer}
           onPress={handleClickMinus}
+          disabled={!isDisabled}
         >
           <Image style={styles.image} source={MINUS_ICON} />
         </TouchableOpacity>
 
         <View style={styles.textContainer}>
-          <Text style={[styles.textNumber, textStyles.title20_SB135]}>
+          <Text
+            style={[
+              textStyles.title20_SB135,
+              { color: isDisabled ? colors.main : colors.gray[1] },
+            ]}
+          >
             {numberOfPeople}
           </Text>
           <Text style={[styles.textUnit, textStyles.body16_SB135]}>명</Text>
@@ -47,6 +62,7 @@ const NumberOfPeopleBox = () => {
         <TouchableOpacity
           style={styles.buttonContainer}
           onPress={handleClickPlus}
+          disabled={!isDisabled}
         >
           <Image style={styles.image} source={PLUS_ICON} />
         </TouchableOpacity>
@@ -60,7 +76,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 16,
     borderRadius: 16,
-    backgroundColor: colors.white,
     shadowColor: "rgba(0, 0, 0, 0.25)",
     shadowOpacity: 0.25,
     shadowOffset: { width: 0, height: 0 },
@@ -88,9 +103,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     gap: 4,
     alignItems: "center",
-  },
-  textNumber: {
-    color: colors.main,
   },
   textUnit: {
     color: colors.gray[1],

--- a/TinyBite/components/create-party/PhotoItem.tsx
+++ b/TinyBite/components/create-party/PhotoItem.tsx
@@ -1,6 +1,8 @@
 import { useCreatingPartyStore } from "@/stores/creatingPartyStore";
+import { useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
+import { useLocalSearchParams } from "expo-router";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useShallow } from "zustand/shallow";
 
@@ -12,23 +14,53 @@ interface PhotoItemProps {
 }
 
 const PhotoItem = ({ id, imageUri }: PhotoItemProps) => {
-  const { deletePhoto, representativePhoto, setRepresentativePhoto } =
-    useCreatingPartyStore(
-      useShallow((state) => ({
-        deletePhoto: state.deletePhoto,
-        representativePhoto: state.representativePhoto,
-        setRepresentativePhoto: state.setRepresentativePhoto,
-      }))
-    );
+  const { mode } = useLocalSearchParams<{
+    mode?: string;
+  }>();
+  const isEditingMode = mode === "edit";
+
+  const {
+    deletePhoto: createDeletePhoto,
+    representativePhoto: createRepresentativePhoto,
+    setRepresentativePhoto: createSetRepresentativePhoto,
+  } = useCreatingPartyStore(
+    useShallow((state) => ({
+      deletePhoto: state.deletePhoto,
+      representativePhoto: state.representativePhoto,
+      setRepresentativePhoto: state.setRepresentativePhoto,
+    }))
+  );
+
+  const {
+    deletePhoto: editDeletePhoto,
+    representativePhoto: editRepresentativePhoto,
+    setRepresentativePhoto: editSetRepresentativePhoto,
+  } = useEditPartyStore(
+    useShallow((state) => ({
+      deletePhoto: state.deletePhoto,
+      representativePhoto: state.representativePhoto,
+      setRepresentativePhoto: state.setRepresentativePhoto,
+    }))
+  );
 
   const onClickDeletePhoto = () => {
-    deletePhoto(id);
+    if (isEditingMode) {
+      editDeletePhoto(id);
+    } else {
+      createDeletePhoto(id);
+    }
   };
 
   return (
     <TouchableOpacity
       style={styles.container}
-      onLongPress={() => setRepresentativePhoto(id)}
+      onLongPress={() => {
+        if (isEditingMode) {
+          editSetRepresentativePhoto(id);
+        } else {
+          createSetRepresentativePhoto(id);
+        }
+      }}
     >
       <View style={styles.imageContainer}>
         <Image
@@ -37,7 +69,10 @@ const PhotoItem = ({ id, imageUri }: PhotoItemProps) => {
           resizeMode="cover"
         />
 
-        {id === representativePhoto && (
+        {id ===
+          (isEditingMode
+            ? editRepresentativePhoto
+            : createRepresentativePhoto) && (
           <View style={styles.textContainer}>
             <Text style={[styles.text, textStyles.body12_M135]}>대표</Text>
           </View>

--- a/TinyBite/components/create-party/SubTitle.tsx
+++ b/TinyBite/components/create-party/SubTitle.tsx
@@ -1,6 +1,8 @@
 import { useCreatingPartyStore } from "@/stores/creatingPartyStore";
+import { useEditPartyStore } from "@/stores/editPartyStore";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
+import { useLocalSearchParams } from "expo-router";
 import { StyleSheet, Text, View } from "react-native";
 import { useShallow } from "zustand/shallow";
 
@@ -11,7 +13,18 @@ interface SubTitleProps {
 }
 
 const SubTitle = ({ subTitle, caption, isPic }: SubTitleProps) => {
-  const { photos } = useCreatingPartyStore(
+  const { mode } = useLocalSearchParams<{
+    mode?: string;
+  }>();
+  const isEditingMode = mode === "edit";
+
+  const { photos: createPhotos } = useCreatingPartyStore(
+    useShallow((state) => ({
+      photos: state.photos,
+    }))
+  );
+
+  const { photos: editPhotos } = useEditPartyStore(
     useShallow((state) => ({
       photos: state.photos,
     }))
@@ -26,7 +39,7 @@ const SubTitle = ({ subTitle, caption, isPic }: SubTitleProps) => {
 
         {isPic ? (
           <Text style={[styles.picCaptionText, textStyles.body16_B150]}>
-            ({photos.length}/5)
+            ({isEditingMode ? editPhotos.length : createPhotos.length}/5)
           </Text>
         ) : (
           <Text style={[styles.captionText, textStyles.body16_SB135]}>

--- a/TinyBite/components/create-party/TextInputBox.tsx
+++ b/TinyBite/components/create-party/TextInputBox.tsx
@@ -14,6 +14,7 @@ interface TextInputBoxProps {
   placeholder: string;
   onChangeText: (text: string) => void;
   value: string;
+  isEditable?: boolean;
 }
 
 const TextInputBox = ({
@@ -23,14 +24,24 @@ const TextInputBox = ({
   placeholder,
   onChangeText,
   value,
+  isEditable = true,
 }: TextInputBoxProps) => {
   return (
-    <View style={styles.container}>
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: isEditable ? colors.white : colors.gray[3] },
+      ]}
+    >
       <View style={styles.inner}>
         {iconType && <Image source={iconUrl[iconType]} />}
 
         <TextInput
-          style={[styles.inputText, textStyles.body16_SB135]}
+          style={[
+            styles.inputText,
+            textStyles.body16_SB135,
+            { color: isEditable ? colors.black : colors.gray[1] },
+          ]}
           placeholder={placeholder}
           placeholderTextColor={colors.gray[1]}
           maxLength={maxLength}
@@ -40,10 +51,18 @@ const TextInputBox = ({
             onChangeText(isAmount ? text.replace(/[^0-9]/g, "") : text);
           }}
           value={value}
+          editable={isEditable}
         />
 
         {isAmount && (
-          <Text style={[styles.amountText, textStyles.body16_SB150]}>원</Text>
+          <Text
+            style={[
+              textStyles.body16_SB150,
+              { color: isEditable ? colors.black : colors.gray[1] },
+            ]}
+          >
+            원
+          </Text>
         )}
       </View>
     </View>
@@ -55,7 +74,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 16,
     borderRadius: 16,
-    backgroundColor: colors.white,
     shadowColor: "rgba(0, 0, 0, 0.25)",
     shadowOpacity: 0.25,
     shadowOffset: { width: 0, height: 0 },
@@ -69,10 +87,6 @@ const styles = StyleSheet.create({
   },
   inputText: {
     flex: 1,
-    color: colors.black,
-  },
-  amountText: {
-    color: colors.black,
   },
 });
 

--- a/TinyBite/hooks/usePartyDetail.ts
+++ b/TinyBite/hooks/usePartyDetail.ts
@@ -8,7 +8,7 @@ import { useQuery } from "@tanstack/react-query";
  * @returns React Query 결과 (data, isLoading, error 등)
  */
 export const usePartyDetail = (params: PartyDetailParams) => {
-  const { data, isLoading, error } = useQuery<PartyDetail>({
+  const { data, isLoading, error, isSuccess } = useQuery<PartyDetail>({
     queryKey: [
       "getPartyDetail",
       params.partyId,
@@ -19,5 +19,5 @@ export const usePartyDetail = (params: PartyDetailParams) => {
     enabled: !!params.partyId && !!params.latitude && !!params.longitude, // partyId, latitude, longitude가 모두 있을 때만 실행
   });
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, isSuccess };
 };

--- a/TinyBite/stores/authStore.ts
+++ b/TinyBite/stores/authStore.ts
@@ -1,4 +1,3 @@
-import { postRefresh } from "@/api/authApi";
 import { LoginRespone, UserProfile } from "@/types/auth";
 import { router } from "expo-router";
 import * as SecureStore from "expo-secure-store";
@@ -9,7 +8,6 @@ export interface AuthState {
   user: UserProfile | null;
   login: (res: LoginRespone) => void;
   logout: () => void;
-  refreshAccessToken: () => Promise<boolean>;
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
@@ -32,20 +30,5 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ user: null, isAuthenticated: false });
 
     router.replace("/login/login");
-  },
-  refreshAccessToken: async (): Promise<boolean> => {
-    try {
-      const data = await postRefresh();
-
-      await SecureStore.setItemAsync("accessToken", data.accessToken);
-      await SecureStore.setItemAsync("refreshToken", data.refreshToken);
-      set({ user: data.user, isAuthenticated: true });
-
-      return true;
-    } catch (error) {
-      console.error("Token refresh failed:", error);
-      get().logout();
-      return false;
-    }
   },
 }));

--- a/TinyBite/stores/authStore.ts
+++ b/TinyBite/stores/authStore.ts
@@ -1,3 +1,4 @@
+import { signOut } from "@/hooks/useGoogleAuth";
 import { LoginRespone, UserProfile } from "@/types/auth";
 import { router } from "expo-router";
 import * as SecureStore from "expo-secure-store";
@@ -23,6 +24,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ user: res.authResponse.user, isAuthenticated: true });
   },
   logout: async () => {
+    await signOut();
     await SecureStore.deleteItemAsync("googleIdToken");
     await SecureStore.deleteItemAsync("accessToken");
     await SecureStore.deleteItemAsync("refreshToken");

--- a/TinyBite/stores/creatingPartyStore.ts
+++ b/TinyBite/stores/creatingPartyStore.ts
@@ -63,6 +63,8 @@ export const useCreatingPartyStore = create<CreatingPartyState>((set, get) => ({
       const updatedPhotos = state.photos.filter((p) => p.id !== id);
       const newRepresentativePhoto =
         updatedPhotos.length === 0
+          ? state.seq + 1
+          : id === state.representativePhoto
           ? updatedPhotos[0].id
           : state.representativePhoto;
 

--- a/TinyBite/stores/creatingPartyStore.ts
+++ b/TinyBite/stores/creatingPartyStore.ts
@@ -14,7 +14,11 @@ export interface CreatingPartyState {
   partyTitle: string;
   totalAmount: string;
   numberOfPeople: number;
-  pickUpLocation: string;
+  pickUpLocation: {
+    place: string;
+    pickupLatitude: number;
+    pickupLongitude: number;
+  };
   detailedDescription: string;
   productLink: string;
   addPhoto: (uri: string, mimeType: string, fileName: string) => void;
@@ -36,7 +40,11 @@ export const useCreatingPartyStore = create<CreatingPartyState>((set, get) => ({
   partyTitle: "",
   totalAmount: "",
   numberOfPeople: 2,
-  pickUpLocation: "",
+  pickUpLocation: {
+    place: "중구 명동",
+    pickupLatitude: 37.569,
+    pickupLongitude: 126.991,
+  },
   detailedDescription: "",
   productLink: "",
   addPhoto: (uri: string, mimeType: string, fileName: string) => {
@@ -95,7 +103,11 @@ export const useCreatingPartyStore = create<CreatingPartyState>((set, get) => ({
   },
   setPickUpLocation: (location: string) => {
     set(() => ({
-      pickUpLocation: location,
+      pickUpLocation: {
+        place: "중구 명동",
+        pickupLatitude: 37.569,
+        pickupLongitude: 126.991,
+      },
     }));
   },
   setDetailedDescription: (description: string) => {
@@ -116,7 +128,11 @@ export const useCreatingPartyStore = create<CreatingPartyState>((set, get) => ({
       partyTitle: "",
       totalAmount: "",
       numberOfPeople: 2,
-      pickUpLocation: "",
+      pickUpLocation: {
+        place: "중구 명동",
+        pickupLatitude: 37.569,
+        pickupLongitude: 126.991,
+      },
       detailedDescription: "",
       productLink: "",
     }));

--- a/TinyBite/stores/editPartyStore.ts
+++ b/TinyBite/stores/editPartyStore.ts
@@ -1,0 +1,215 @@
+import { Photo } from "@/stores/creatingPartyStore";
+import { PartyDetail } from "@/types/party";
+import { create } from "zustand";
+
+export interface PhotoUrl {
+  id: number;
+  imageUri: string;
+}
+
+export interface editPartyState {
+  seq: number;
+  partyId: number;
+  photos: (Photo | PhotoUrl)[];
+  representativePhoto: number;
+  title: {
+    isEdited: boolean;
+    value: string;
+  };
+  totalPrice: {
+    isEdited: boolean;
+    value: string;
+  };
+  maxParticipants: {
+    isEdited: boolean;
+    value: number;
+  };
+  pickupLocation: {
+    isEdited: boolean;
+    value: string;
+  };
+  latitude: {
+    isEdited: boolean;
+    value: number;
+  };
+  longitude: {
+    isEdited: boolean;
+    value: number;
+  };
+  description: string;
+  productLink: {
+    isEdited: boolean;
+    value: string;
+  };
+
+  setInitialPartyInfo: (info: PartyDetail) => void;
+  addPhoto: (uri: string, mimeType: string, fileName: string) => void;
+  deletePhoto: (id: number) => void;
+  setRepresentativePhoto: (id: number) => void;
+  setPartyTitle: (title: string) => void;
+  setTotalAmount: (amount: string) => void;
+  setPickUpLocation: (location: string) => void;
+  setDetailedDescription: (description: string) => void;
+  setProductLink: (link: string) => void;
+  setMaxParticipants: (number: number) => void;
+}
+
+export const useEditPartyStore = create<editPartyState>((set) => ({
+  seq: 0,
+  partyId: 0,
+  photos: [],
+  representativePhoto: 0,
+  title: {
+    isEdited: false,
+    value: "",
+  },
+  totalPrice: {
+    isEdited: false,
+    value: "",
+  },
+  maxParticipants: {
+    isEdited: false,
+    value: 2,
+  },
+  pickupLocation: {
+    isEdited: false,
+    value: "",
+  },
+  latitude: {
+    isEdited: false,
+    value: 37.569,
+  },
+  longitude: {
+    isEdited: false,
+    value: 126.991,
+  },
+  description: "",
+  productLink: {
+    isEdited: false,
+    value: "",
+  },
+
+  setInitialPartyInfo: (info: PartyDetail) =>
+    set({
+      seq: info.images.length,
+      partyId: info.partyId,
+      photos: info.images.map((imageUri, index) => ({
+        id: index + 1,
+        imageUri: imageUri,
+      })),
+      representativePhoto: info.images.length > 0 ? 1 : 0,
+      title: {
+        isEdited: false,
+        value: info.title,
+      },
+      totalPrice: {
+        isEdited: false,
+        value: info.totalPrice.toString(),
+      },
+      maxParticipants: {
+        isEdited: false,
+        value: info.maxParticipants,
+      },
+      pickupLocation: {
+        isEdited: false,
+        value: info.pickupLocation.place,
+      },
+      latitude: {
+        isEdited: false,
+        value: info.pickupLocation.pickupLatitude,
+      },
+      longitude: {
+        isEdited: false,
+        value: info.pickupLocation.pickupLongitude,
+      },
+      description: info.description || "",
+      productLink: {
+        isEdited: false,
+        value: info.productLink?.url || "",
+      },
+    }),
+  setPartyTitle: (title: string) => {
+    set(() => ({
+      title: {
+        isEdited: true,
+        value: title,
+      },
+    }));
+  },
+  addPhoto: (uri: string, mimeType: string, fileName: string) => {
+    set((state) => {
+      const nextSeq = state.seq + 1;
+      const newPhoto: Photo = {
+        id: nextSeq,
+        imageUri: uri,
+        mimeType: mimeType,
+        fileName: fileName,
+      };
+      const newRepresentativePhoto =
+        state.photos.length === 0 ? newPhoto.id : state.representativePhoto;
+
+      return {
+        seq: nextSeq,
+        photos: [...state.photos, newPhoto],
+        representativePhoto: newRepresentativePhoto,
+      };
+    });
+  },
+  deletePhoto: (id: number) => {
+    set((state) => {
+      const updatedPhotos = state.photos.filter((p) => p.id !== id);
+      const newRepresentativePhoto =
+        updatedPhotos.length === 0
+          ? state.seq + 1
+          : id === state.representativePhoto
+          ? updatedPhotos[0].id
+          : state.representativePhoto;
+
+      return {
+        photos: updatedPhotos,
+        representativePhoto: newRepresentativePhoto,
+      };
+    });
+  },
+  setRepresentativePhoto: (id: number) =>
+    set(() => ({
+      representativePhoto: id,
+    })),
+  setTotalAmount: (amount: string) => {
+    set(() => ({
+      totalPrice: {
+        isEdited: true,
+        value: amount,
+      },
+    }));
+  },
+  setPickUpLocation: (location: string) => {
+    set(() => ({
+      pickupLocation: {
+        isEdited: true,
+        value: location,
+      },
+    }));
+  },
+  setDetailedDescription: (description: string) => {
+    set(() => ({
+      description: description,
+    }));
+  },
+  setProductLink: (link: string) => {
+    set(() => ({
+      productLink: {
+        isEdited: true,
+        value: link,
+      },
+    }));
+  },
+  setMaxParticipants: (number: number) => {
+    set(() => ({
+      maxParticipants: {
+        isEdited: true,
+        value: number,
+      },
+    }));
+  },
+}));

--- a/TinyBite/stores/editPartyStore.ts
+++ b/TinyBite/stores/editPartyStore.ts
@@ -52,6 +52,7 @@ export interface editPartyState {
   setDetailedDescription: (description: string) => void;
   setProductLink: (link: string) => void;
   setMaxParticipants: (number: number) => void;
+  resetEditParty: () => void;
 }
 
 export const useEditPartyStore = create<editPartyState>((set) => ({
@@ -212,4 +213,40 @@ export const useEditPartyStore = create<editPartyState>((set) => ({
       },
     }));
   },
+  resetEditParty: () =>
+    set({
+      seq: 0,
+      partyId: 0,
+      photos: [],
+      representativePhoto: 0,
+      title: {
+        isEdited: false,
+        value: "",
+      },
+      totalPrice: {
+        isEdited: false,
+        value: "",
+      },
+      maxParticipants: {
+        isEdited: false,
+        value: 2,
+      },
+      pickupLocation: {
+        isEdited: false,
+        value: "",
+      },
+      latitude: {
+        isEdited: false,
+        value: 37.569,
+      },
+      longitude: {
+        isEdited: false,
+        value: 126.991,
+      },
+      description: "",
+      productLink: {
+        isEdited: false,
+        value: "",
+      },
+    }),
 }));

--- a/TinyBite/stores/editPartyStore.ts
+++ b/TinyBite/stores/editPartyStore.ts
@@ -26,15 +26,9 @@ export interface editPartyState {
   };
   pickupLocation: {
     isEdited: boolean;
-    value: string;
-  };
-  latitude: {
-    isEdited: boolean;
-    value: number;
-  };
-  longitude: {
-    isEdited: boolean;
-    value: number;
+    place: string;
+    pickupLatitude: number;
+    pickupLongitude: number;
   };
   description: string;
   productLink: {
@@ -74,15 +68,9 @@ export const useEditPartyStore = create<editPartyState>((set) => ({
   },
   pickupLocation: {
     isEdited: false,
-    value: "",
-  },
-  latitude: {
-    isEdited: false,
-    value: 37.569,
-  },
-  longitude: {
-    isEdited: false,
-    value: 126.991,
+    place: "",
+    pickupLatitude: 37.569,
+    pickupLongitude: 126.991,
   },
   description: "",
   productLink: {
@@ -113,15 +101,9 @@ export const useEditPartyStore = create<editPartyState>((set) => ({
       },
       pickupLocation: {
         isEdited: false,
-        value: info.pickupLocation.place,
-      },
-      latitude: {
-        isEdited: false,
-        value: info.pickupLocation.pickupLatitude,
-      },
-      longitude: {
-        isEdited: false,
-        value: info.pickupLocation.pickupLongitude,
+        place: info.pickupLocation.place,
+        pickupLatitude: info.pickupLocation.pickupLatitude,
+        pickupLongitude: info.pickupLocation.pickupLongitude,
       },
       description: info.description || "",
       productLink: {
@@ -188,7 +170,9 @@ export const useEditPartyStore = create<editPartyState>((set) => ({
     set(() => ({
       pickupLocation: {
         isEdited: true,
-        value: location,
+        place: "중구 명동",
+        pickupLatitude: 37.569,
+        pickupLongitude: 126.991,
       },
     }));
   },
@@ -233,15 +217,9 @@ export const useEditPartyStore = create<editPartyState>((set) => ({
       },
       pickupLocation: {
         isEdited: false,
-        value: "",
-      },
-      latitude: {
-        isEdited: false,
-        value: 37.569,
-      },
-      longitude: {
-        isEdited: false,
-        value: 126.991,
+        place: "",
+        pickupLatitude: 37.569,
+        pickupLongitude: 126.991,
       },
       description: "",
       productLink: {

--- a/TinyBite/types/party.ts
+++ b/TinyBite/types/party.ts
@@ -123,9 +123,11 @@ export type EditedPartyInfo = {
   title?: string;
   totalPrice?: number;
   maxParticipants?: number;
-  pickupLocation?: string;
-  latitude?: number;
-  longitude?: number;
+  pickupLocation?: {
+    place: string;
+    pickupLatitude?: number;
+    pickupLongitude?: number;
+  };
   productLink?: string;
   description?: string;
   images?: string[];

--- a/TinyBite/types/party.ts
+++ b/TinyBite/types/party.ts
@@ -124,7 +124,7 @@ export type EditedPartyInfo = {
   pickupLocation?: string;
   latitude?: number;
   longitude?: number;
-  productLink?: ProductLink;
+  productLink?: string;
   description?: string;
   images?: string[];
 };

--- a/TinyBite/types/party.ts
+++ b/TinyBite/types/party.ts
@@ -118,13 +118,13 @@ export type PartyDetail = {
  * 파티 수정 정보 타입
  */
 export type EditedPartyInfo = {
-  title: string;
-  totalPrice: number;
-  maxParticipants: number;
-  pickupLocation: string;
-  latitude: number;
-  longitude: number;
-  productLink: ProductLink;
-  description: string;
-  images: string[];
+  title?: string;
+  totalPrice?: number;
+  maxParticipants?: number;
+  pickupLocation?: string;
+  latitude?: number;
+  longitude?: number;
+  productLink?: ProductLink;
+  description?: string;
+  images?: string[];
 };

--- a/TinyBite/types/party.ts
+++ b/TinyBite/types/party.ts
@@ -49,6 +49,8 @@ export type CreatingPartyBody = {
   maxParticipants: number;
   pickupLocation: {
     place: string;
+    pickupLatitude: number;
+    pickupLongitude: number;
   };
   images?: string[];
   productLink?: string;

--- a/TinyBite/types/party.ts
+++ b/TinyBite/types/party.ts
@@ -113,3 +113,18 @@ export type PartyDetail = {
   isClosed: boolean;
   isParticipating: boolean;
 };
+
+/**
+ * 파티 수정 정보 타입
+ */
+export type EditedPartyInfo = {
+  title: string;
+  totalPrice: number;
+  maxParticipants: number;
+  pickupLocation: string;
+  latitude: number;
+  longitude: number;
+  productLink: ProductLink;
+  description: string;
+  images: string[];
+};


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

<!-- title 규칙 → feat/#이슈번호: (작업 내용) -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#78 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

크게 두 부분 구현했습니다. 

우선 파티 수정인데요.
`app/party-detail/[id].tsx`에서 `useEditPartyStore`의 `setInitialPartyInfo`를 통해서 해당 파티 상세 정보를 저장하게 했고,
`app/party/edit/[type].tsx`에서 `useEditPartyStore`에 저장해둔 정보를 사용해 파티 내용을 우선 보여주고, `useEditPartyStore`를 통해서 수정한 파티 정보를 관리할 수 있도록 했습니다. 파티 수정 api에 보내는 정보는, 수정한 정보만 `patchParty` api에 보내도록 했어요. 
이때, 사진, 설명, 위치정보는 항상 보내도록 했습니다.

파티 생성과 수정 모두 위치정보(위치 설명, latitude, longitude)는 모두 '중구 명동', 37.569, 126.991으로 하드코딩 해두었습니다. 그래야 현재 유저(저는 중구 명동을 현재 위치로 설정했으니)에게 생성한 파티가 보이더라구요..

다른 하나는 accessToken 만료시 refreshToken을 활용한 accessToken 갱신 로직을 수정했습니다. 
`ENDPOINT.AUTH.REFRESH` 이 엔드포인트를 사용해서 refreshToken을 보낼 때 publicAxios을 사용했어야 했는데 제가 privateAxios를 사용했더라구요..
그리고 로그아웃시에 기기에서 google 계정 로그아웃도 되도록 수정해두었습니다!

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
