### PR TITLE
feat/#90: 회원탈퇴 API 연결

### DIFF
--- a/TinyBite/app/(mypage)/setting.tsx
+++ b/TinyBite/app/(mypage)/setting.tsx
@@ -1,5 +1,5 @@
 import { postLogout } from "@/api/authApi";
-import { getUserMe } from "@/api/userApi";
+import { deleteUserMe, getUserMe } from "@/api/userApi";
 import ConfirmModal from "@/components/ConfirmModal";
 import { useAuthStore } from "@/stores/authStore";
 import { colors } from "@/styles/colors";
@@ -13,11 +13,12 @@ import { StatusBar } from "expo-status-bar";
 import { useState } from "react";
 import { Image, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import Toast from "react-native-toast-message";
 import { useShallow } from "zustand/shallow";
 export default function SettingScreen() {
   const router = useRouter();
   const [showLogoutModal, setShowLogoutModal] = useState(false);
-  //const [showWithdrawModal, setShowWithdrawModal] = useState(false);
+  const [showWithdrawModal, setShowWithdrawModal] = useState(false);
 
   const { logout } = useAuthStore(
     useShallow((state) => ({
@@ -45,7 +46,6 @@ export default function SettingScreen() {
       }
     },
   });
-  /*
   const withdrawMutation = useMutation({
     mutationFn: deleteUserMe,
     onSuccess: () => {
@@ -79,7 +79,6 @@ export default function SettingScreen() {
       }
     },
   });
-*/
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar style="dark" />
@@ -94,7 +93,6 @@ export default function SettingScreen() {
         <Text style={[styles.headerTitle, textStyles.title20_B135]}>설정</Text>
         <View style={styles.placeholder} />
       </View>
-
       {/* Content */}
       <View style={styles.contentWrapper}>
         {/* 알림 설정 */}
@@ -163,7 +161,6 @@ export default function SettingScreen() {
             style={styles.chevronIcon}
           />
         </Pressable>
-        {/*
         <View style={styles.divider} />
         <Pressable
           style={styles.settingItem}
@@ -183,9 +180,7 @@ export default function SettingScreen() {
             style={styles.chevronIcon}
           />
         </Pressable>
-        */}
       </View>
-
       {/* 로그아웃 확인 모달 */}
       <ConfirmModal
         visible={showLogoutModal}
@@ -198,12 +193,11 @@ export default function SettingScreen() {
           logoutMutation.mutateAsync();
         }}
       />
-
-      {/* 회원탈퇴 확인 모달 
+      {/* 회원탈퇴 확인 모달 */}
       <ConfirmModal
         visible={showWithdrawModal}
         title="회원 탈퇴"
-        message={`회원 탈퇴 시 계정 정보 및 저장된 모든 정보가\n삭제 되어 복구가 불가해요.\n\n정말 탈퇴하시겠어요?`}
+        message={`회원 탈퇴 시 계정 정보 및 저장된 모든 정보가\n삭제 되어 30일 간 복구가 불가해요.\n\n정말 탈퇴하시겠어요?`}
         cancelText="아니오"
         confirmText="예"
         onClose={() => setShowWithdrawModal(false)}
@@ -211,7 +205,6 @@ export default function SettingScreen() {
           withdrawMutation.mutateAsync();
         }}
       />
-      */}
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## ⚙️ Related ISSUE Number
#90 

<br><br>
## 📄 Work Description
### 개요
회원 탈퇴 기능을 구현하고 UI를 개선했습니다.

### 작업 내용

### 1. 회원 탈퇴 API 구현

#### API 함수 추가
- **파일**: `api/userApi.ts`
- `deleteUserMe` 함수 추가
- DELETE 요청으로 `/api/v1/user/me` 엔드포인트 호출

### 2. 회원 탈퇴 UI 구현

#### 설정 화면에 회원 탈퇴 옵션 추가
- **파일**: `app/(mypage)/setting.tsx`
- 회원 탈퇴 버튼 추가
- 확인 모달 구현
- 탈퇴 성공/실패 처리

#### 구현 내용
- `withdrawMutation` 추가 (`deleteUserMe` API 사용)
- `showWithdrawModal` 상태로 모달 표시 제어
- `ConfirmModal` 컴포넌트 사용

### 3. 회원 탈퇴 확인 모달

#### 모달 내용
- **제목**: "회원 탈퇴"
- **메시지**: "회원 탈퇴 시 계정 정보 및 저장된 모든 정보가\n삭제 되어 30일 간 복구가 불가해요.\n\n정말 탈퇴하시겠어요?"
- **버튼**: "아니오", "예"


## 주요 기능

1. ✅ **회원 탈퇴 API 연동**
   - `deleteUserMe` API 함수 구현
   - DELETE 요청으로 사용자 계정 삭제

2. ✅ **회원 탈퇴 UI**
   - 설정 화면에 회원 탈퇴 옵션 추가
   - 확인 모달로 사용자 확인 받기
   - 성공 시 토스트 메시지 표시 및 로그아웃

3. ✅ **에러 처리**
   - API 에러 시 적절한 에러 메시지 표시
   - 네트워크 에러 처리

4. ✅ **메시지 개선**
   - "30일 간 복구가 불가해요"로 명확한 안내

## 관련 파일

- `api/userApi.ts` - 회원 탈퇴 API 함수
- `app/(mypage)/setting.tsx` - 설정 화면 (회원 탈퇴 UI)
- `components/ConfirmModal.tsx` - 확인 모달 컴포넌트
- `utils/getErrorMessage.ts` - 에러 메시지 변환

<br><br>
## 📷 Screenshot
<img width="282" height="596" alt="스크린샷 2026-01-03 오전 9 21 30" src="https://github.com/user-attachments/assets/8ebca0c8-6988-4ca5-b298-88e74e2c4f4d" />
<img width="288" height="601" alt="스크린샷 2026-01-03 오전 9 25 50" src="https://github.com/user-attachments/assets/153d7541-75ad-4082-a5db-aa03b49c9fc2" />

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
