### PR TITLE
Fix/94 키보드 노출 시 화면이 함께 올라가는 문제

### DIFF
--- a/TinyBite/app/_layout.tsx
+++ b/TinyBite/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { toastConfig } from "@/lib/toast/toastConfig";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Stack } from "expo-router";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import Toast from "react-native-toast-message";
 
 const queryClient = new QueryClient();
@@ -8,12 +9,14 @@ const queryClient = new QueryClient();
 export default function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="index" />
-        <Stack.Screen name="(tabs)" />
-        <Stack.Screen name="party-detail/[id]" />
-      </Stack>
-      <Toast config={toastConfig} />
+      <KeyboardProvider>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="index" />
+          <Stack.Screen name="(tabs)" />
+          <Stack.Screen name="party-detail/[id]" />
+        </Stack>
+        <Toast config={toastConfig} />
+      </KeyboardProvider>
     </QueryClientProvider>
   );
 }

--- a/TinyBite/app/party/create/[type].tsx
+++ b/TinyBite/app/party/create/[type].tsx
@@ -16,6 +16,7 @@ import { AxiosError } from "axios";
 import { router, useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { FlatList, ScrollView, StyleSheet, View } from "react-native";
+import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { useShallow } from "zustand/shallow";
@@ -196,89 +197,94 @@ export default function PartyCreateScreen() {
       <View style={styles.container}>
         <CreatePartyPageHeader title={title} />
 
-        <ScrollView style={styles.contentContainer}>
-          <SafeAreaView style={styles.contentInner} edges={["bottom"]}>
-            <View style={styles.section}>
-              <SubTitle subTitle="사진 등록" isPic />
-              <View style={styles.photoContainer}>
-                <AddPhotoButton />
-                <FlatList
-                  data={photos}
-                  renderItem={renderItem}
-                  keyExtractor={(item) => item.id.toString()}
-                  horizontal={true}
-                  contentContainerStyle={{ gap: 8 }}
-                />
-              </View>
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="파티 제목" caption="(메뉴명)" />
-              <TextInputBox
-                placeholder={config.titlePlaceholder}
-                maxLength={30}
-                onChangeText={setPartyTitle}
-                value={partyTitle}
-              />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="예상 총 주문 금액" />
-              <TextInputBox
-                placeholder="0"
-                isAmount
-                onChangeText={setTotalAmount}
-                value={totalAmount}
-              />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="모집 인원" caption="(나 포함)" />
-              <NumberOfPeopleBox />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="수령 장소" />
-              <TextInputBox
-                iconType="location"
-                placeholder="예) 역삼역 1번 출구"
-                maxLength={30}
-                onChangeText={setPickUpLocation}
-                value={pickUpLocation.place}
-              />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="상세 설명" />
-              <TextInputBox
-                placeholder="추가로 전달 할 내용이 있다면 적어주세요."
-                maxLength={60}
-                onChangeText={setDetailedDescription}
-                value={detailedDescription}
-              />
-            </View>
-
-            {config.showProductLink && (
+        <KeyboardAwareScrollView contentContainerStyle={{ flex: 1 }}>
+          <ScrollView style={styles.contentContainer}>
+            <View style={styles.contentInner}>
               <View style={styles.section}>
-                <SubTitle subTitle="상품 링크" />
+                <SubTitle subTitle="사진 등록" isPic />
+                <View style={styles.photoContainer}>
+                  <AddPhotoButton />
+                  <FlatList
+                    data={photos}
+                    renderItem={renderItem}
+                    keyExtractor={(item) => item.id.toString()}
+                    horizontal={true}
+                    contentContainerStyle={{ gap: 8 }}
+                  />
+                </View>
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="파티 제목" caption="(메뉴명)" />
                 <TextInputBox
-                  iconType="link"
-                  placeholder="구매할 상품의 URL을 입력하세요."
-                  onChangeText={setProductLink}
-                  value={productLink}
+                  placeholder={config.titlePlaceholder}
+                  maxLength={30}
+                  onChangeText={setPartyTitle}
+                  value={partyTitle}
                 />
               </View>
-            )}
-          </SafeAreaView>
-        </ScrollView>
 
-        <SafeAreaView style={styles.createButtonContainer} edges={["bottom"]}>
-          <GlobalButton
-            onClick={onClickCreateParty}
-            text="파티 시작하기"
-            disabled={!isValid()}
-          />
-        </SafeAreaView>
+              <View style={styles.section}>
+                <SubTitle subTitle="예상 총 주문 금액" />
+                <TextInputBox
+                  placeholder="0"
+                  isAmount
+                  onChangeText={setTotalAmount}
+                  value={totalAmount}
+                />
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="모집 인원" caption="(나 포함)" />
+                <NumberOfPeopleBox />
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="수령 장소" />
+                <TextInputBox
+                  iconType="location"
+                  placeholder="예) 역삼역 1번 출구"
+                  maxLength={30}
+                  onChangeText={setPickUpLocation}
+                  value={pickUpLocation.place}
+                />
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="상세 설명" />
+                <TextInputBox
+                  placeholder="추가로 전달 할 내용이 있다면 적어주세요."
+                  maxLength={60}
+                  onChangeText={setDetailedDescription}
+                  value={detailedDescription}
+                />
+              </View>
+
+              {config.showProductLink && (
+                <View style={styles.section}>
+                  <SubTitle subTitle="상품 링크" />
+                  <TextInputBox
+                    iconType="link"
+                    placeholder="구매할 상품의 URL을 입력하세요."
+                    onChangeText={setProductLink}
+                    value={productLink}
+                  />
+                </View>
+              )}
+            </View>
+
+            <SafeAreaView
+              style={styles.createButtonContainer}
+              edges={["bottom"]}
+            >
+              <GlobalButton
+                onClick={onClickCreateParty}
+                text="파티 시작하기"
+                disabled={!isValid()}
+              />
+            </SafeAreaView>
+          </ScrollView>
+        </KeyboardAwareScrollView>
       </View>
     </>
   );

--- a/TinyBite/app/party/create/[type].tsx
+++ b/TinyBite/app/party/create/[type].tsx
@@ -272,18 +272,15 @@ export default function PartyCreateScreen() {
                 </View>
               )}
             </View>
-
-            <SafeAreaView
-              style={styles.createButtonContainer}
-              edges={["bottom"]}
-            >
-              <GlobalButton
-                onClick={onClickCreateParty}
-                text="파티 시작하기"
-                disabled={!isValid()}
-              />
-            </SafeAreaView>
           </ScrollView>
+
+          <SafeAreaView style={styles.createButtonContainer} edges={["bottom"]}>
+            <GlobalButton
+              onClick={onClickCreateParty}
+              text="파티 시작하기"
+              disabled={!isValid()}
+            />
+          </SafeAreaView>
         </KeyboardAwareScrollView>
       </View>
     </>

--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -17,6 +17,7 @@ import { AxiosError } from "axios";
 import { router, useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { FlatList, ScrollView, StyleSheet, View } from "react-native";
+import { KeyboardAwareScrollView } from "react-native-keyboard-controller";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { useShallow } from "zustand/shallow";
@@ -208,89 +209,91 @@ export default function PartyCreateScreen() {
       <View style={styles.container}>
         <CreatePartyPageHeader title="파티 수정" />
 
-        <ScrollView style={styles.contentContainer}>
-          <SafeAreaView style={styles.contentInner} edges={["bottom"]}>
-            <View style={styles.section}>
-              <SubTitle subTitle="사진 등록" isPic />
-              <View style={styles.photoContainer}>
-                <AddPhotoButton />
-                <FlatList
-                  data={photos}
-                  renderItem={renderItem}
-                  keyExtractor={(item) => item.id.toString()}
-                  horizontal={true}
-                  contentContainerStyle={{ gap: 8 }}
-                />
-              </View>
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="파티 제목" caption="(메뉴명)" />
-              <TextInputBox
-                placeholder={config.titlePlaceholder}
-                maxLength={30}
-                onChangeText={setPartyTitle}
-                value={title.value}
-                isEditable={isAllEditable}
-              />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="예상 총 주문 금액" />
-              <TextInputBox
-                placeholder="0"
-                isAmount
-                onChangeText={setTotalAmount}
-                value={totalPrice.value}
-                isEditable={isAllEditable}
-              />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="모집 인원" caption="(나 포함)" />
-              <NumberOfPeopleBox isDisabled={isAllEditable} />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="수령 장소" />
-              <TextInputBox
-                iconType="location"
-                placeholder="예) 역삼역 1번 출구"
-                maxLength={30}
-                onChangeText={setPickUpLocation}
-                value={pickupLocation.place}
-                isEditable={isAllEditable}
-              />
-            </View>
-
-            <View style={styles.section}>
-              <SubTitle subTitle="상세 설명" />
-              <TextInputBox
-                placeholder="추가로 전달 할 내용이 있다면 적어주세요."
-                maxLength={60}
-                onChangeText={setDetailedDescription}
-                value={description}
-              />
-            </View>
-
-            {config.showProductLink && (
+        <KeyboardAwareScrollView contentContainerStyle={{ flex: 1 }}>
+          <ScrollView style={styles.contentContainer}>
+            <SafeAreaView style={styles.contentInner} edges={["bottom"]}>
               <View style={styles.section}>
-                <SubTitle subTitle="상품 링크" />
+                <SubTitle subTitle="사진 등록" isPic />
+                <View style={styles.photoContainer}>
+                  <AddPhotoButton />
+                  <FlatList
+                    data={photos}
+                    renderItem={renderItem}
+                    keyExtractor={(item) => item.id.toString()}
+                    horizontal={true}
+                    contentContainerStyle={{ gap: 8 }}
+                  />
+                </View>
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="파티 제목" caption="(메뉴명)" />
                 <TextInputBox
-                  iconType="link"
-                  placeholder="구매할 상품의 URL을 입력하세요."
-                  onChangeText={setProductLink}
-                  value={productLink.value}
+                  placeholder={config.titlePlaceholder}
+                  maxLength={30}
+                  onChangeText={setPartyTitle}
+                  value={title.value}
                   isEditable={isAllEditable}
                 />
               </View>
-            )}
-          </SafeAreaView>
-        </ScrollView>
 
-        <SafeAreaView style={styles.createButtonContainer} edges={["bottom"]}>
-          <GlobalButton onClick={onClickEditParty} text="완료" />
-        </SafeAreaView>
+              <View style={styles.section}>
+                <SubTitle subTitle="예상 총 주문 금액" />
+                <TextInputBox
+                  placeholder="0"
+                  isAmount
+                  onChangeText={setTotalAmount}
+                  value={totalPrice.value}
+                  isEditable={isAllEditable}
+                />
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="모집 인원" caption="(나 포함)" />
+                <NumberOfPeopleBox isDisabled={isAllEditable} />
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="수령 장소" />
+                <TextInputBox
+                  iconType="location"
+                  placeholder="예) 역삼역 1번 출구"
+                  maxLength={30}
+                  onChangeText={setPickUpLocation}
+                  value={pickupLocation.place}
+                  isEditable={isAllEditable}
+                />
+              </View>
+
+              <View style={styles.section}>
+                <SubTitle subTitle="상세 설명" />
+                <TextInputBox
+                  placeholder="추가로 전달 할 내용이 있다면 적어주세요."
+                  maxLength={60}
+                  onChangeText={setDetailedDescription}
+                  value={description}
+                />
+              </View>
+
+              {config.showProductLink && (
+                <View style={styles.section}>
+                  <SubTitle subTitle="상품 링크" />
+                  <TextInputBox
+                    iconType="link"
+                    placeholder="구매할 상품의 URL을 입력하세요."
+                    onChangeText={setProductLink}
+                    value={productLink.value}
+                    isEditable={isAllEditable}
+                  />
+                </View>
+              )}
+            </SafeAreaView>
+          </ScrollView>
+
+          <SafeAreaView style={styles.createButtonContainer} edges={["bottom"]}>
+            <GlobalButton onClick={onClickEditParty} text="완료" />
+          </SafeAreaView>
+        </KeyboardAwareScrollView>
       </View>
     </>
   );

--- a/TinyBite/package-lock.json
+++ b/TinyBite/package-lock.json
@@ -39,6 +39,7 @@
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-image-viewing": "^0.2.2",
+        "react-native-keyboard-controller": "1.18.5",
         "react-native-reanimated": "~4.1.1",
         "react-native-reanimated-carousel": "^4.0.3",
         "react-native-safe-area-context": "~5.6.0",
@@ -97,7 +98,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1479,7 +1479,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3138,7 +3137,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.26.tgz",
       "integrity": "sha512-RhKmeD0E2ejzKS6z8elAfdfwShpcdkYY8zJzvHYLq+wv183BBcElTeyMLcIX6wIn7QutXeI92Yi21t7aUWfqNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.13.7",
         "escape-string-regexp": "^4.0.0",
@@ -3363,7 +3361,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3434,7 +3431,6 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3996,7 +3992,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4699,7 +4694,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5710,7 +5704,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5907,7 +5900,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6146,7 +6138,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.30.tgz",
       "integrity": "sha512-6q+aFfKL0SpT8prfdpR3V8HcN51ov0mCGuwQTzyuk6eeO9rg7a7LWbgPv9rEVXGZEuyULstL8LGNwHqusand7Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.20",
@@ -6214,7 +6205,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.12.tgz",
       "integrity": "sha512-WzcKYMVNRRu4NcSzfIVRD5aUQFnSpTZgXFrlWmm19xJoDa4S3/PQNi6PNTBRc49xz9h8FT7HMxRKaC8lr0gflA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.12",
         "@expo/env": "~2.0.8"
@@ -6324,7 +6314,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.10.tgz",
       "integrity": "sha512-UqyNaaLKRpj4pKAP4HZSLnuDQqueaO5tB1c/NWu5vh1/LF9ulItyyg2kF/IpeOp0DeOLk0GY0HrIXaKUMrwB+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6413,7 +6402,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -10476,7 +10464,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10496,7 +10483,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10533,7 +10519,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -10591,7 +10576,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -10622,12 +10606,25 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.5.tgz",
+      "integrity": "sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
       "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -10668,7 +10665,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -10679,7 +10675,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -10705,7 +10700,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -10738,7 +10732,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -10849,7 +10842,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12161,7 +12153,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12368,7 +12359,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/TinyBite/package.json
+++ b/TinyBite/package.json
@@ -42,6 +42,7 @@
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-image-viewing": "^0.2.2",
+    "react-native-keyboard-controller": "1.18.5",
     "react-native-reanimated": "~4.1.1",
     "react-native-reanimated-carousel": "^4.0.3",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

<!-- title 규칙 → feat/#이슈번호: (작업 내용) -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#94 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

`react-native-keyboard-controller`를 사용해서 키보드가 올라올 때 보이는 뷰를 조절했습니다. 
다만, 뷰 자체를 키보드 위로 좁히는거라서 파티 생성 버튼을 키보드 아래(밑)로 고정시키는 게 안되더라구요. 지금처럼 항상 키보드 위에 고정되어 있거나, 다른 인풋 요소들처럼 스크롤을 해야 보이는 식으로만 구현이 가능할 것 같습니다. 이 부분은 추후 기획/디자인 쪽에서 구현 관련 이야기가 나오면 상의해봐야 할 것 같아요. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="381" height="834" alt="image" src="https://github.com/user-attachments/assets/6fe525fb-3253-4f21-b0df-96c128de033f" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->

[keyboard-controller](https://docs.expo.dev/versions/latest/sdk/keyboard-controller/)
[KeyboardProvider](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/installation#adding-provider)
