### PR TITLE
fix/#100: 파티 수정 후 뒤로가기 동작 개선

### DIFF
--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -101,7 +101,7 @@ export default function PartyCreateScreen() {
     mutationFn: patchParty,
     onSuccess: (data) => {
       resetEditParty();
-      router.replace(`/party-detail/${partyId}`);
+      router.dismissTo(`/party-detail/${partyId}`);
     },
     onError: (error: AxiosError<ApiError>) => {
       if (error.response?.data) {


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

<!-- title 규칙 → feat/#이슈번호: (작업 내용) -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#100 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

수정 완료 후 reouter를 dismissTo로 변경했습니다.
이렇게 하니 페이지의 뒤로가기 버튼을 누르면 바로 홈 화면으로 가집니다.

수정 완료 후 이동한 상세 페이지에서 업데이트 내용을 반영하는 건 별도로 수정해야할 것 같아요.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


https://github.com/user-attachments/assets/90a30fe6-3a5b-4814-a064-5a703f89a450



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
[Router](https://docs.expo.dev/versions/latest/sdk/router/#router)