### PR TITLE
Feat/#102: 마이페이지 내가 만든 파티 구현

### DIFF
--- a/TinyBite/api/partyApi.ts
+++ b/TinyBite/api/partyApi.ts
@@ -155,3 +155,17 @@ export const getActiveParties = async (): Promise<PartyItem[]> => {
     return [];
   }
 };
+
+/**
+ * 호스팅 중인 파티 리스트 조회 API
+ * @returns 호스팅 중인 파티 리스트
+ */
+export const getHostingParties = async (): Promise<PartyItem[]> => {
+  try {
+    const res = await privateAxios.get(ENDPOINT.USER.HOSTING_PARTIES);
+    return res.data || [];
+  } catch (error) {
+    console.error("호스팅 중인 파티 리스트 로딩 실패:", error);
+    return [];
+  }
+};

--- a/TinyBite/api/urls.ts
+++ b/TinyBite/api/urls.ts
@@ -30,6 +30,7 @@ export const ENDPOINT = {
     ME: "/api/v1/user/me",
     NICKNAME_CHECK: "/api/v1/user/nickname/check",
     LOCATION: "/api/v1/user/me/location",
-    ACTIVE_PARTIES: "/api/v1/user/parties/active",
+    ACTIVE_PARTIES: "/api/v1/user/parties/participating",
+    HOSTING_PARTIES: "/api/v1/user/parties/hosting",
   },
 };

--- a/TinyBite/app/(tabs)/mypage.tsx
+++ b/TinyBite/app/(tabs)/mypage.tsx
@@ -1,33 +1,19 @@
-import { getActiveParties } from "@/api/partyApi";
 import { getUserMe } from "@/api/userApi";
-import MainCard from "@/components/main/MainCard";
+import MyPartyList from "@/components/mypage/MyPartyList";
 import { colors } from "@/styles/colors";
 import { textStyles } from "@/styles/typography/textStyles";
-import { PartyItem } from "@/types/party";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import {
-  Image,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { Image, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function MyPageScreen() {
   const router = useRouter();
+
   const { data: userMe } = useQuery({
     queryKey: ["getUserMe"],
     queryFn: getUserMe,
-  });
-
-  // 참여중인 파티 리스트 조회
-  const { data: activeParties = [], isLoading } = useQuery<PartyItem[]>({
-    queryKey: ["getActiveParties"],
-    queryFn: getActiveParties,
   });
   return (
     <SafeAreaView style={styles.container} edges={["top"]}>
@@ -90,41 +76,8 @@ export default function MyPageScreen() {
           </Pressable>
         </View>
       </View>
-      <View style={styles.sectionWrapper}>
-        <Text style={[styles.sectionTitle, textStyles.body16_B150]}>
-          참여 중인 파티
-        </Text>
-      </View>
-      {/* Content */}
-      <ScrollView style={styles.contentWrapper}>
-        {isLoading ? (
-          <View style={styles.emptyContainer}>
-            <Text style={[styles.emptyText, textStyles.body16_SB135]}>
-              로딩 중...
-            </Text>
-          </View>
-        ) : activeParties.length === 0 ? (
-          <View style={styles.emptyContainer}>
-            <Text style={[styles.emptyText, textStyles.body16_SB135]}>
-              참여 중인 파티가 없습니다.
-            </Text>
-          </View>
-        ) : (
-          activeParties.map((item) => (
-            <MainCard
-              key={item.partyId}
-              item={item}
-              containerStyle={styles.mypageCard}
-              onPress={() =>
-                router.push({
-                  pathname: "/party-detail/[id]" as any,
-                  params: { id: item.partyId.toString() },
-                })
-              }
-            />
-          ))
-        )}
-      </ScrollView>
+      {/* Party List */}
+      <MyPartyList />
     </SafeAreaView>
   );
 }
@@ -189,29 +142,5 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     color: colors.black,
-  },
-  contentWrapper: {
-    flex: 1,
-    backgroundColor: colors.background,
-    paddingHorizontal: 20,
-  },
-  mypageCard: {
-    borderRadius: 0,
-    shadowColor: "transparent",
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 0,
-    shadowRadius: 0,
-    elevation: 0,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.gray[4],
-  },
-  emptyContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    paddingTop: 40,
-  },
-  emptyText: {
-    color: colors.gray[1],
   },
 });

--- a/TinyBite/app/party-detail/[id].tsx
+++ b/TinyBite/app/party-detail/[id].tsx
@@ -158,6 +158,9 @@ export default function PartyDetailScreen() {
                 await deleteParty(partyId);
                 // 파티 리스트 쿼리 무효화하여 자동으로 새로고침
                 queryClient.invalidateQueries({ queryKey: ["getParties"] });
+                queryClient.invalidateQueries({
+                  queryKey: ["getHostingParties"],
+                });
                 router.back();
                 return true;
               } catch (error: any) {

--- a/TinyBite/app/party-detail/[id].tsx
+++ b/TinyBite/app/party-detail/[id].tsx
@@ -148,7 +148,7 @@ export default function PartyDetailScreen() {
                   type: "GROCERY",
                   mode: "edit",
                   allEditable: (
-                    partyDetail.currentParticipants === 0
+                    partyDetail.currentParticipants === 1
                   ).toString(),
                 },
               });
@@ -161,7 +161,7 @@ export default function PartyDetailScreen() {
                 queryClient.invalidateQueries({
                   queryKey: ["getHostingParties"],
                 });
-                router.back();
+                router.replace("/(tabs)");
                 return true;
               } catch (error: any) {
                 // 400(이미 참여자가 있음 / 권한 없음) 상태 코드인 경우 에러 로그 출력하지 않음

--- a/TinyBite/app/party/edit/[type].tsx
+++ b/TinyBite/app/party/edit/[type].tsx
@@ -101,6 +101,7 @@ export default function PartyCreateScreen() {
     mutationFn: patchParty,
     onSuccess: (data) => {
       resetEditParty();
+      router.back();
       router.replace(`/party-detail/${partyId}`);
     },
     onError: (error: AxiosError<ApiError>) => {

--- a/TinyBite/components/main/FloatingMenuOverlay.tsx
+++ b/TinyBite/components/main/FloatingMenuOverlay.tsx
@@ -161,7 +161,7 @@ const styles = StyleSheet.create({
   floatingButtonInModal: {
     position: "absolute",
     right: 20,
-    bottom: 100,
+    bottom: 110,
   },
 });
 

--- a/TinyBite/components/mypage/MyPartyList.tsx
+++ b/TinyBite/components/mypage/MyPartyList.tsx
@@ -1,0 +1,191 @@
+import { getActiveParties, getHostingParties } from "@/api/partyApi";
+import MainCard from "@/components/main/MainCard";
+import { colors } from "@/styles/colors";
+import { textStyles } from "@/styles/typography/textStyles";
+import { PartyItem } from "@/types/party";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+type TabType = "active" | "hosting";
+
+/**
+ * 마이페이지 파티 리스트 컴포넌트
+ * - 참여 중인 파티 / 내가 만든 파티 탭 전환
+ * - 각 탭에 맞는 파티 리스트 표시
+ */
+const MyPartyList = () => {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState<TabType>("active");
+
+  // 참여중인 파티 리스트 조회
+  const { data: activeParties = [], isLoading: isLoadingActive } = useQuery<
+    PartyItem[]
+  >({
+    queryKey: ["getActiveParties"],
+    queryFn: getActiveParties,
+  });
+
+  // 호스팅 중인 파티 리스트 조회
+  const { data: hostingParties = [], isLoading: isLoadingHosting } = useQuery<
+    PartyItem[]
+  >({
+    queryKey: ["getHostingParties"],
+    queryFn: getHostingParties,
+    enabled: activeTab === "hosting",
+  });
+
+  const isLoading = activeTab === "active" ? isLoadingActive : isLoadingHosting;
+  const parties = activeTab === "active" ? activeParties : hostingParties;
+  const emptyText =
+    activeTab === "active"
+      ? "참여 중인 파티가 없습니다."
+      : "내가 만든 파티가 없습니다.";
+
+  return (
+    <View style={styles.container}>
+      {/* 탭 바 */}
+      <View style={styles.tabBarContainer}>
+        <View style={styles.grayUnderline} />
+        <View style={styles.tabBar}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.tab,
+              { opacity: pressed ? 0.6 : 1 },
+            ]}
+            onPress={() => setActiveTab("active")}
+          >
+            <Text
+              style={[
+                textStyles.body16_SB135,
+                {
+                  color: activeTab === "active" ? colors.main : colors.gray[2],
+                },
+              ]}
+            >
+              참여 중인 파티
+            </Text>
+            {activeTab === "active" && <View style={styles.indicator} />}
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [
+              styles.tab,
+              { opacity: pressed ? 0.6 : 1 },
+            ]}
+            onPress={() => setActiveTab("hosting")}
+          >
+            <Text
+              style={[
+                textStyles.body16_SB135,
+                {
+                  color: activeTab === "hosting" ? colors.main : colors.gray[2],
+                },
+              ]}
+            >
+              내가 만든 파티
+            </Text>
+            {activeTab === "hosting" && <View style={styles.indicator} />}
+          </Pressable>
+        </View>
+      </View>
+
+      {/* 콘텐츠 */}
+      {isLoading ? (
+        <View style={styles.emptyContainer}>
+          <Text style={[styles.emptyText, textStyles.body16_SB135]}>
+            로딩 중...
+          </Text>
+        </View>
+      ) : parties.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <Text style={[styles.emptyText, textStyles.body16_SB135]}>
+            {emptyText}
+          </Text>
+        </View>
+      ) : (
+        <ScrollView style={styles.contentWrapper}>
+          {parties.map((item) => (
+            <MainCard
+              key={item.partyId}
+              item={item}
+              containerStyle={styles.mypageCard}
+              onPress={() =>
+                router.push({
+                  pathname: "/party-detail/[id]" as any,
+                  params: { id: item.partyId.toString() },
+                })
+              }
+            />
+          ))}
+        </ScrollView>
+      )}
+    </View>
+  );
+};
+
+export default MyPartyList;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  tabBarContainer: {
+    backgroundColor: colors.background,
+    paddingHorizontal: 20,
+    position: "relative",
+  },
+  tabBar: {
+    flexDirection: "row",
+    backgroundColor: "transparent",
+  },
+  tab: {
+    flex: 1,
+    alignItems: "center",
+    paddingBottom: 12,
+  },
+  indicator: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 4,
+    backgroundColor: colors.main,
+    borderRadius: 2,
+    zIndex: 2,
+  },
+  grayUnderline: {
+    position: "absolute",
+    bottom: 0,
+    left: 20,
+    right: 20,
+    height: 4,
+    backgroundColor: colors.gray[4],
+    borderRadius: 2,
+    zIndex: 0,
+  },
+  contentWrapper: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  mypageCard: {
+    borderRadius: 0,
+    paddingHorizontal: 30,
+    shadowColor: "transparent",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0,
+    shadowRadius: 0,
+    elevation: 0,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray[4],
+  },
+  emptyContainer: {
+    flex: 1,
+    backgroundColor: colors.background,
+    paddingTop: 40,
+    alignItems: "center",
+  },
+  emptyText: {
+    color: colors.gray[1],
+  },
+});


### PR DESCRIPTION
## ⚙️ Related ISSUE Number
#102 

<br><br>
## 📄 Work Description
### 📋 작업 개요
마이페이지에 "내가 만든 파티" 탭을 추가하고, "참여 중인 파티"와 "내가 만든 파티"를 탭으로 전환할 수 있도록 구현했습니다.

### 🔧 주요 변경사항

### 1. API 추가 및 수정
**파일**: `api/urls.ts`, `api/partyApi.ts`

**내용**:
- 호스팅 중인 파티 조회 엔드포인트 추가: `/api/v1/user/parties/hosting`
- `getHostingParties()` API 함수 추가
- 참여 중인 파티 엔드포인트 추가: `/api/v1/user/parties/participating`

### 2. UI 컴포넌트 추가
**파일**: `components/mypage/MyPartyList.tsx` (신규)

**내용**:
- 커스텀 탭 구현 (Pressable 기반)
- "참여 중인 파티" / "내가 만든 파티" 탭 전환 기능
- 활성 탭에 오렌지 인디케이터 표시
- 전체 너비 회색 밑줄
- 각 탭별 파티 리스트 표시
- 빈 상태 처리 (로딩 중, 데이터 없음)

### 3. 마이페이지 화면 수정
**파일**: `app/(tabs)/mypage.tsx`

**내용**:
- `MyPartyList` 컴포넌트로 파티 리스트 로직 분리
- 코드 간소화 및 재사용성 향상

### 4. 파티 삭제 후 리스트 새로고침
**파일**: `app/party-detail/[id].tsx`

**내용**:
- 파티 삭제 성공 시 `getHostingParties` 쿼리 무효화 추가
- 삭제 후 마이페이지 리스트 자동 업데이트

## 📁 변경된 파일

- `api/partyApi.ts` - 호스팅 파티 API 함수 추가
- `api/urls.ts` - 호스팅 파티 엔드포인트 추가
- `app/(tabs)/mypage.tsx` - MyPartyList 컴포넌트 사용
- `app/party-detail/[id].tsx` - 삭제 후 쿼리 무효화 추가
- `components/mypage/MyPartyList.tsx` - 신규 컴포넌트 추가


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->
